### PR TITLE
Refactor Studio State Management to Centralized Memory Module (ESL-2)

### DIFF
--- a/studio/memory.py
+++ b/studio/memory.py
@@ -1,0 +1,59 @@
+import json
+import os
+import fcntl
+from typing import List
+from pydantic import BaseModel, ValidationError
+
+class StudioStateSchema(BaseModel):
+    phase: str
+    step: int
+    active_agent: str
+    artifacts: List[str]
+
+class StudioMemory:
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+    def load(self) -> StudioStateSchema:
+        if not os.path.exists(self.file_path):
+            # Return a default state if file doesn't exist,
+            # though the tests assume it exists from fixture.
+            return StudioStateSchema(
+                phase="IDLE",
+                step=0,
+                active_agent="Orchestrator",
+                artifacts=[]
+            )
+
+        with open(self.file_path, 'r') as f:
+            # Apply shared lock for reading
+            fcntl.flock(f, fcntl.LOCK_SH)
+            try:
+                data = json.load(f)
+                return StudioStateSchema(**data)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+    def save(self, state: StudioStateSchema):
+        self._write_to_file(state.model_dump())
+
+    def save_raw(self, data: dict):
+        # This will trigger Pydantic validation if we try to convert it
+        # but the test expects it to raise an exception.
+        # Let's ensure we validate before saving.
+        validated_state = StudioStateSchema(**data)
+        self.save(validated_state)
+
+    def _write_to_file(self, data: dict):
+        # Atomic write with exclusive lock
+        temp_path = self.file_path + ".tmp"
+        with open(temp_path, 'w') as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                json.dump(data, f, indent=4)
+                f.flush()
+                os.fsync(f.fileno())
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+        os.replace(temp_path, self.file_path)

--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -1,71 +1,36 @@
 import os
-import json
 import shutil
-import tempfile
-from typing import Any, Dict
+from typing import Any
+from studio.memory import StudioMemory, StudioStateSchema
 
-class StudioManager:
+class Orchestrator:
     """
-    The Manager — The Autopilot
-    Monitors system health via studio_state.json.
+    The Orchestrator — The Autopilot
+    Monitors system health via StudioMemory.
     Routes work to PM, Architect, or Optimizer.
     Implements Circuit Breakers.
-    SOLE authority for writing to studio_state.json.
+    SOLE authority for writing to studio_state.json via StudioMemory.
     """
-
-    DEFAULT_STATE = {
-        "version": "1.0",
-        "evolution_queue": [],
-        "meta": {
-            "schema_version": "1.0",
-            "system_status": "BOOTSTRAP"
-        }
-    }
 
     def __init__(self, root_dir: str = "."):
         self.root_dir = root_dir
         self.state_path = os.path.join(self.root_dir, "studio_state.json")
-        self.state = self._load_state()
+        self.memory = StudioMemory(self.state_path)
+        self.state = self.memory.load()
 
-    def _load_state(self) -> Dict[str, Any]:
+    def update_state(self, **kwargs):
         """
-        AGENTS.md Sec 9.1: Manager is the State Owner.
-        Verify it creates a valid default state file if none exists.
+        Updates fields in the state and saves it.
         """
-        if not os.path.exists(self.state_path):
-            state = self.DEFAULT_STATE.copy()
-            self.state = state
-            self._save_state()
-            return state
-
-        with open(self.state_path, "r") as f:
-            try:
-                return json.load(f)
-            except json.JSONDecodeError:
-                return self.DEFAULT_STATE.copy()
-
-    def _save_state(self):
-        """
-        AGENTS.md Sec 9: Data Sovereignty.
-        Ensure _save_state() writes to a temporary file first, then renames it (atomic write).
-        """
-        fd, temp_path = tempfile.mkstemp(dir=self.root_dir, text=True)
-        with os.fdopen(fd, 'w') as f:
-            json.dump(self.state, f, indent=4)
-
-        os.replace(temp_path, self.state_path)
-
-    def update_state(self, key: str, value: Any):
-        """
-        Updates a key in the state and saves it.
-        """
-        self.state[key] = value
-        self._save_state()
+        current_state_dict = self.state.model_dump()
+        current_state_dict.update(kwargs)
+        self.state = StudioStateSchema(**current_state_dict)
+        self.memory.save(self.state)
 
     def perform_atomic_swap(self, candidate_path: str, target_path: str):
         """
         AGENTS.md Sec 4 (ESL-2): The Atomic Swap.
-        Verify the Manager can swap a candidate file into production
+        Verify the Orchestrator can swap a candidate file into production
         ONLY if the file exists.
         """
         full_candidate_path = os.path.join(self.root_dir, candidate_path)

--- a/studio/studio_state.json
+++ b/studio/studio_state.json
@@ -1,30 +1,6 @@
 {
-    "meta": {
-        "schema_version": "1.0",
-        "last_updated": "2026-02-07T12:00:00.000000+00:00",
-        "system_status": "BOOTSTRAP",
-        "consecutive_success_count": 0
-    },
-    "registry": {
-        "screener": {
-            "role": "product",
-            "version": "0.1.0",
-            "source_file": "bsp_agent/screener.py",
-            "health": { "status": "PENDING" }
-        },
-        "pathologist": {
-            "role": "product",
-            "version": "0.1.0",
-            "source_file": "bsp_agent/pathologist.py",
-            "health": { "status": "PENDING" }
-        },
-        "librarian": {
-            "role": "product",
-            "version": "0.1.0",
-            "source_file": "bsp_agent/librarian.py",
-            "health": { "status": "PENDING" }
-        }
-    },
-    "evolution_queue": [],
-    "history_log_pointer": "studio/review_history.md"
+    "phase": "IDLE",
+    "step": 0,
+    "active_agent": "Orchestrator",
+    "artifacts": []
 }

--- a/tests/studio/test_memory_persistence.py
+++ b/tests/studio/test_memory_persistence.py
@@ -1,0 +1,62 @@
+import pytest
+import json
+import os
+from studio.memory import StudioMemory, StudioStateSchema
+
+# Fixture: A temporary state file to prevent overwriting the real studio_state.json
+@pytest.fixture
+def temp_state_file(tmp_path):
+    f = tmp_path / "test_studio_state.json"
+    initial_state = {
+        "phase": "IDLE",
+        "step": 0,
+        "active_agent": "Orchestrator",
+        "artifacts": []
+    }
+    f.write_text(json.dumps(initial_state))
+    return str(f)
+
+def test_memory_load_and_validate(temp_state_file):
+    """
+    Scenario: The Orchestrator initializes memory.
+    Expectation: Data is loaded and validates against the Pydantic Schema.
+    """
+    memory = StudioMemory(file_path=temp_state_file)
+    state = memory.load()
+
+    assert state.phase == "IDLE"
+    assert isinstance(state, StudioStateSchema)
+
+def test_memory_update_state(temp_state_file):
+    """
+    Scenario: The Orchestrator updates the phase to 'RED'.
+    Expectation: The file on disk is updated with the new value.
+    """
+    memory = StudioMemory(file_path=temp_state_file)
+
+    # Mutate
+    new_state = memory.load()
+    new_state.phase = "RED"
+    new_state.step = 1
+
+    memory.save(new_state)
+
+    # Verify persistence
+    with open(temp_state_file, 'r') as f:
+        data = json.load(f)
+        assert data["phase"] == "RED"
+        assert data["step"] == 1
+
+def test_schema_violation_raises_error(temp_state_file):
+    """
+    Scenario: Attempting to save an invalid state (violating strict typing).
+    Expectation: Pydantic ValidationError prevents corruption of the JSON file.
+    """
+    memory = StudioMemory(file_path=temp_state_file)
+    state = memory.load()
+
+    # Invalid assignment (e.g., step should be int, not string)
+    # Note: Pydantic v2 might coerce, so we test a missing required field or totally wrong type
+    with pytest.raises(Exception): # Catch Pydantic ValidationError
+        bad_data = {"phase": "RED"} # Missing other fields
+        memory.save_raw(bad_data)


### PR DESCRIPTION
This PR implements the Centralized Memory Module for the Studio, as mandated by Section 5 of AGENTS.md. It moves state management from raw JSON manipulation in the Orchestrator to a dedicated `studio/memory.py` module using Pydantic for validation and `fcntl` for safe concurrent access. The Orchestrator (formerly StudioManager) has been refactored to use this new abstraction.

Fixes #16

---
*PR created automatically by Jules for task [15282411893439027967](https://jules.google.com/task/15282411893439027967) started by @jonaschen*