### PR TITLE
Refactor Studio State Management

### DIFF
--- a/tests/studio_golden/test_manager_core.py
+++ b/tests/studio_golden/test_manager_core.py
@@ -2,17 +2,19 @@ import pytest
 import json
 import os
 import shutil
-from studio.manager import StudioManager
+from studio.orchestrator import Orchestrator
+from studio.memory import StudioMeta
 
 # Fixture: Temporary Studio Environment
 @pytest.fixture
 def temp_studio(tmp_path):
-    state_file = tmp_path / "studio_state.json"
+    # StudioMemory prefers studio/studio_state.json if studio/ exists
+    state_file = tmp_path / "studio" / "studio_state.json"
     candidate_dir = tmp_path / "studio" / "_candidate"
     target_dir = tmp_path / "studio"
 
     candidate_dir.mkdir(parents=True)
-    # target_dir already exists because of parents=True and it being parent of candidate_dir
+    # target_dir exists
 
     return {
         "root": tmp_path,
@@ -26,13 +28,13 @@ def test_manager_initializes_state(temp_studio):
     AGENTS.md Sec 9.1: Manager is the State Owner.
     Verify it creates a valid default state file if none exists.
     """
-    mgr = StudioManager(root_dir=str(temp_studio["root"]))
+    mgr = Orchestrator(root_dir=str(temp_studio["root"]))
 
     assert temp_studio["state"].exists()
     with open(temp_studio["state"]) as f:
         data = json.load(f)
-        assert "version" in data
-        assert "evolution_queue" in data
+        assert "studio_meta" in data
+        assert "orchestration_state" in data
 
 def test_atomic_swap_protocol(temp_studio):
     """
@@ -40,7 +42,7 @@ def test_atomic_swap_protocol(temp_studio):
     Verify the Manager can swap a candidate file into production
     ONLY if the file exists.
     """
-    mgr = StudioManager(root_dir=str(temp_studio["root"]))
+    mgr = Orchestrator(root_dir=str(temp_studio["root"]))
 
     # Setup: Create a candidate file (New Logic)
     candidate_file = temp_studio["candidate"] / "architect.py"
@@ -51,7 +53,6 @@ def test_atomic_swap_protocol(temp_studio):
     target_file.write_text("print('Old Logic')")
 
     # Action: Perform Swap
-    # Note: In a real scenario, this is only called after tests pass.
     mgr.perform_atomic_swap(
         candidate_path="studio/_candidate/architect.py",
         target_path="studio/architect.py"
@@ -59,7 +60,7 @@ def test_atomic_swap_protocol(temp_studio):
 
     # Assert: Target now contains New Logic
     assert target_file.read_text() == "print('New Logic')"
-    # Assert: Candidate is cleaned up (optional, but good hygiene)
+    # Assert: Candidate is cleaned up
     assert not candidate_file.exists()
 
 def test_state_write_lock_enforcement(temp_studio):
@@ -67,9 +68,17 @@ def test_state_write_lock_enforcement(temp_studio):
     AGENTS.md Sec 9.3: Violation Consequences.
     Ensure the Manager writes safely (simulated).
     """
-    mgr = StudioManager(root_dir=str(temp_studio["root"]))
-    mgr.update_state(key="current_sprint", value=1)
+    mgr = Orchestrator(root_dir=str(temp_studio["root"]))
+
+    # Create a new StudioMeta object
+    new_meta = StudioMeta(
+        system_version="TEST_VERSION",
+        constitution_hash="TEST_HASH",
+        current_phase="TEST_PHASE"
+    )
+
+    mgr.update_state(key="studio_meta", value=new_meta)
 
     with open(temp_studio["state"]) as f:
         data = json.load(f)
-        assert data["current_sprint"] == 1
+        assert data["studio_meta"]["current_phase"] == "TEST_PHASE"


### PR DESCRIPTION
Refactored the Studio's internal state management to ensure data sovereignty and robust state tracking.
Implemented `studio/memory.py` as the interface for state persistence using Pydantic models.
Renamed `studio/manager.py` to `studio/orchestrator.py` and updated the `Orchestrator` class to use `StudioMemory`.
Updated `studio/studio_state.json` management to be exclusively handled by the Orchestrator via `StudioMemory`.
Verified changes with updated tests in `tests/studio_golden/test_manager_core.py`.

---
*PR created automatically by Jules for task [14578582024493528497](https://jules.google.com/task/14578582024493528497) started by @jonaschen*