### PR TITLE
Refactor Studio State Management to use Pydantic Models

### DIFF
--- a/studio/manager.py
+++ b/studio/manager.py
@@ -3,6 +3,11 @@ import json
 import shutil
 import tempfile
 from typing import Any, Dict
+from datetime import datetime, timezone
+from studio.memory import (
+    StudioState, StudioMeta, OrchestrationState, SprintBoard,
+    EngineeringState, OptimizationState, EpisodicMemory, VerificationGate
+)
 
 class StudioManager:
     """
@@ -13,36 +18,58 @@ class StudioManager:
     SOLE authority for writing to studio_state.json.
     """
 
-    DEFAULT_STATE = {
-        "version": "1.0",
-        "evolution_queue": [],
-        "meta": {
-            "schema_version": "1.0",
-            "system_status": "BOOTSTRAP"
-        }
-    }
-
     def __init__(self, root_dir: str = "."):
         self.root_dir = root_dir
         self.state_path = os.path.join(self.root_dir, "studio_state.json")
         self.state = self._load_state()
 
-    def _load_state(self) -> Dict[str, Any]:
+    def _get_default_state(self) -> StudioState:
+        return StudioState(
+            studio_meta=StudioMeta(
+                system_version="5.1.0",
+                constitution_hash="sha256:default",
+                current_phase="BOOTSTRAP"
+            ),
+            orchestration_state=OrchestrationState(
+                sprint_board=SprintBoard(
+                    sprint_id="SPRINT-00",
+                    sprint_goal="Bootstrap Studio",
+                    start_date=datetime.now(timezone.utc).isoformat(),
+                    end_date=datetime.now(timezone.utc).isoformat()
+                )
+            ),
+            engineering_state=EngineeringState(
+                verification_gate=VerificationGate(status="PENDING")
+            ),
+            optimization_state=OptimizationState(target_prompt=""),
+            episodic_memory=EpisodicMemory()
+        )
+
+    def _load_state(self) -> StudioState:
         """
         AGENTS.md Sec 9.1: Manager is the State Owner.
         Verify it creates a valid default state file if none exists.
         """
         if not os.path.exists(self.state_path):
-            state = self.DEFAULT_STATE.copy()
+            state = self._get_default_state()
             self.state = state
             self._save_state()
             return state
 
         with open(self.state_path, "r") as f:
             try:
-                return json.load(f)
-            except json.JSONDecodeError:
-                return self.DEFAULT_STATE.copy()
+                data = json.load(f)
+                return StudioState.model_validate(data)
+            except (json.JSONDecodeError, Exception):
+                # If corrupt or invalid, backup and reset (or just reset for MVP)
+                # For safety, we should probably backup.
+                if os.path.getsize(self.state_path) > 0:
+                    shutil.copy2(self.state_path, self.state_path + ".corrupt")
+
+                state = self._get_default_state()
+                self.state = state
+                self._save_state()
+                return state
 
     def _save_state(self):
         """
@@ -50,17 +77,50 @@ class StudioManager:
         Ensure _save_state() writes to a temporary file first, then renames it (atomic write).
         """
         fd, temp_path = tempfile.mkstemp(dir=self.root_dir, text=True)
+        # Use model_dump_json to serialize Pydantic model
+        json_str = self.state.model_dump_json(indent=4)
+
         with os.fdopen(fd, 'w') as f:
-            json.dump(self.state, f, indent=4)
+            f.write(json_str)
 
         os.replace(temp_path, self.state_path)
 
     def update_state(self, key: str, value: Any):
         """
         Updates a key in the state and saves it.
+        Supports dot notation for nested keys (e.g., 'orchestration_state.sprint_board.sprint_id').
         """
-        self.state[key] = value
+        keys = key.split('.')
+        target = self.state
+
+        # Traverse to the parent of the target key
+        for k in keys[:-1]:
+            if hasattr(target, k):
+                target = getattr(target, k)
+            elif isinstance(target, dict) and k in target:
+                target = target[k]
+            else:
+                # If we can't traverse, we might need to handle it or raise error.
+                # For robustness, we might want to fail explicitly.
+                raise KeyError(f"Key path '{key}' not found in state.")
+
+        final_key = keys[-1]
+
+        # Update the value
+        if hasattr(target, final_key):
+             setattr(target, final_key, value)
+        elif isinstance(target, dict):
+            target[final_key] = value
+        else:
+             raise KeyError(f"Cannot update key '{final_key}' on object {type(target)}")
+
         self._save_state()
+
+    def get_view_for_agent(self, role: str) -> Dict[str, Any]:
+        """
+        Delegates to StudioState.get_view_for_agent.
+        """
+        return self.state.get_view_for_agent(role)
 
     def perform_atomic_swap(self, candidate_path: str, target_path: str):
         """

--- a/studio/memory.py
+++ b/studio/memory.py
@@ -12,7 +12,7 @@ Layers:
 """
 
 from typing import List, Dict, Optional, Literal, Union, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field, HttpUrl, validator
 
 # --- Primitive Types ---
@@ -106,7 +106,7 @@ class SprintBoard(BaseModel):
 class InteractionTurn(BaseModel):
     role: Literal["user", "assistant", "system"]
     content: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 class InquirySession(BaseModel):
     privacy_level: PrivacyLevel = "CONFIDENTIAL_USER_DATA"
@@ -125,7 +125,7 @@ class StudioMeta(BaseModel):
     constitution_hash: str
     current_phase: str
     simulation_mode: bool = False
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 class StudioState(BaseModel):
     """

--- a/tests/studio_golden/test_manager_core.py
+++ b/tests/studio_golden/test_manager_core.py
@@ -31,8 +31,11 @@ def test_manager_initializes_state(temp_studio):
     assert temp_studio["state"].exists()
     with open(temp_studio["state"]) as f:
         data = json.load(f)
-        assert "version" in data
-        assert "evolution_queue" in data
+        assert "studio_meta" in data
+        assert "orchestration_state" in data
+        assert "engineering_state" in data
+        assert "optimization_state" in data
+        assert "episodic_memory" in data
 
 def test_atomic_swap_protocol(temp_studio):
     """
@@ -68,8 +71,11 @@ def test_state_write_lock_enforcement(temp_studio):
     Ensure the Manager writes safely (simulated).
     """
     mgr = StudioManager(root_dir=str(temp_studio["root"]))
-    mgr.update_state(key="current_sprint", value=1)
+
+    # Use a valid key path from the schema
+    # orchestration_state.sprint_board.sprint_id is a good candidate
+    mgr.update_state(key="orchestration_state.sprint_board.sprint_id", value="SPRINT-99")
 
     with open(temp_studio["state"]) as f:
         data = json.load(f)
-        assert data["current_sprint"] == 1
+        assert data["orchestration_state"]["sprint_board"]["sprint_id"] == "SPRINT-99"


### PR DESCRIPTION
Refactored `studio/manager.py` (Orchestrator) to use `StudioState` from `studio/memory.py` for state management, enforcing data sovereignty and schema validation.
- Updated `StudioManager` to load, validate, and save `studio_state.json` using Pydantic models.
- Implemented `update_state` with support for nested key updates via dot notation.
- Added `get_view_for_agent` to delegate to `StudioState`.
- Updated `tests/studio_golden/test_manager_core.py` to align with the new state structure.
- Fixed deprecation warnings by replacing `datetime.utcnow()` with `datetime.now(timezone.utc)`.
- Verified `studio_state.json` against the schema.

---
*PR created automatically by Jules for task [18022952642823318672](https://jules.google.com/task/18022952642823318672) started by @jonaschen*