### PR TITLE
Inject SemanticHealthMetric and implement Orchestrator state machine

### DIFF
--- a/studio/memory.py
+++ b/studio/memory.py
@@ -70,7 +70,6 @@ class OrchestrationState(BaseModel):
     guidance_sop: Optional[SOPState] = None
     # The active context slice being processed
     current_context_slice: Optional[ContextSlice] = None
-    latest_entropy: float = 0.0
 
 # Layer 2: Engineering (The TDD Loop)
 class VerificationGate(BaseModel):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -15,10 +15,6 @@ def test_orchestrator_coding_flow():
     orchestrator = Orchestrator()
 
     # Run the graph
-    # LangGraph invoke returns the final state dict or object depending on config.
-    # Given StateGraph(StudioState), it usually returns a dict matching the schema if not configured to return object.
-    # However, since we return updates, it accumulates.
-    # Let's check the type of final_state.
     final_state = orchestrator.app.invoke(state)
 
     # If final_state is a dict, we access keys.
@@ -33,23 +29,20 @@ def test_orchestrator_coding_flow():
 
     # Assertions
     # 1. Intent should be CODING
-    # Pydantic model or dict? LangGraph usually returns a dict if input was dict, or object if object.
-    # We passed an object 'state'. LangGraph usually converts to dict internally if not typed strongly?
-    # But let's handle both.
-
     if isinstance(orch, dict):
          assert orch["user_intent"] == "CODING"
          assert orch["current_context_slice"] is not None
          assert orch["current_context_slice"]["slice_id"].startswith("slice_")
          assert eng["proposed_patch"] == "Patch applied."
-         assert orch["latest_entropy"] == 0.5
+         # assert orch["latest_entropy"] == 0.5 # Removed
     else:
          assert orch.user_intent == "CODING"
          assert orch.current_context_slice is not None
          assert orch.current_context_slice.slice_id.startswith("slice_")
          assert eng.proposed_patch == "Patch applied."
-         assert orch.latest_entropy == 0.5
+         # assert orch.latest_entropy == 0.5 # Removed
 
+    # Check Circuit Breaker (Should be False as entropy is 0.5 < 7.0)
     assert not cb
 
 def test_orchestrator_sop_flow():


### PR DESCRIPTION
Updated `studio/memory.py` to include `SemanticHealthMetric` and `AgentStepOutput` schemas, and removed `latest_entropy` from `OrchestrationState`.
Implemented `studio/orchestrator.py` using `langgraph` to create a state machine that utilizes these new metrics.
- Implemented `intent_router` based on `TriageStatus`.
- Implemented `context_slicer` to generate `ContextSlice`.
- Implemented `engineer_subgraph` and `sop_guide_subgraph` wrappers.
- Implemented circuit breaker logic triggering on `is_tunneling`.
- Verified changes with `tests/test_orchestrator.py`.

---
*PR created automatically by Jules for task [2704409158874707751](https://jules.google.com/task/2704409158874707751) started by @jonaschen*