### PR TITLE
Fix broken import in studio/review_agent.py

### DIFF
--- a/studio/memory.py
+++ b/studio/memory.py
@@ -256,6 +256,22 @@ class ReviewVerdict(BaseModel):
     violations: List[Violation] = []
     adr_entry: Optional[ArchitecturalDecisionRecord] = Field(None, description="New rule to record if needed")
 
+# Legacy / Review Agent Artifacts
+class ReviewSummary(BaseModel):
+    """
+    Summary of the semantic review from the Review Agent.
+    """
+    status: Literal["PASSED", "FAILED"]
+    root_cause: str
+    suggested_fix: str
+
+class ReviewResult(BaseModel):
+    """
+    Final result of the review process.
+    """
+    approved: bool
+    feedback: str
+
 # From Scrum Master Agent
 class ProcessOptimization(BaseModel):
     """A specific suggestion to improve the System."""

--- a/studio/review_agent.py
+++ b/studio/review_agent.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from langchain_google_vertexai import ChatVertexAI
 import re
 from langchain_core.messages import HumanMessage
-from studio.schemas import ReviewSummary, ReviewResult
+from studio.memory import ReviewSummary, ReviewResult
 
 class ReviewAgentOutputError(Exception):
     """Raised when the Review Agent output cannot be parsed as JSON."""

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -1,0 +1,46 @@
+import unittest
+import sys
+import os
+from unittest.mock import MagicMock
+
+# Mock dotenv before importing studio.review_agent
+sys.modules["dotenv"] = MagicMock()
+sys.modules["langchain_google_vertexai"] = MagicMock()
+sys.modules["langchain_core"] = MagicMock()
+sys.modules["langchain_core.messages"] = MagicMock()
+
+# Ensure studio can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+class TestReviewAgentImport(unittest.TestCase):
+    def test_import_review_agent(self):
+        """Test that studio.review_agent can be imported."""
+        try:
+            from studio import review_agent
+            self.assertTrue(True)
+        except ImportError as e:
+             self.fail(f"Failed to import studio.review_agent: {e}")
+        except Exception as e:
+            self.fail(f"An error occurred during import: {e}")
+
+    def test_review_agent_instantiation(self):
+        """Test that ReviewAgent can be instantiated and methods called."""
+        from studio.review_agent import ReviewAgent
+
+        # Mock environment variables
+        with unittest.mock.patch.dict(os.environ, {"PROJECT_ID": "test-project"}):
+             agent = ReviewAgent()
+             # Manually mock LLM since it's disabled in tests by default logic
+             agent.llm = MagicMock()
+
+             # Setup mock LLM response
+             mock_response = MagicMock()
+             mock_response.content = '{"status": "PASSED", "root_cause": "Looks good", "suggested_fix": "None"}'
+             agent.llm.invoke.return_value = mock_response
+
+             summary = agent.analyze("diff content")
+             self.assertEqual(summary.status, "PASSED")
+             self.assertEqual(summary.root_cause, "Looks good")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes a `ModuleNotFoundError` in `studio/review_agent.py` caused by importing from the non-existent `studio.schemas` module.

The missing Pydantic models `ReviewSummary` and `ReviewResult` were added to `studio/memory.py`, which serves as the central location for data models. `studio/review_agent.py` was updated to import these models from `studio.memory`.

A new test file `tests/test_review_agent.py` was added to verify that the module can be imported and instantiated correctly.

---
*PR created automatically by Jules for task [12725688633956030262](https://jules.google.com/task/12725688633956030262) started by @jonaschen*