### PR TITLE
🧹 Remove unused imports in ProductOwnerAgent

### DIFF
--- a/studio/agents/product_owner.py
+++ b/studio/agents/product_owner.py
@@ -17,7 +17,7 @@ Dependencies:
 
 import logging
 import hashlib
-from typing import List, Dict, Optional, Set
+from typing import List, Dict
 from pydantic import BaseModel, Field
 
 from langchain_google_vertexai import ChatVertexAI

--- a/verify_unused.py
+++ b/verify_unused.py
@@ -1,0 +1,21 @@
+import ast
+import sys
+
+def check_unused_imports(filepath):
+    with open(filepath, "r") as f:
+        tree = ast.parse(f.read())
+
+    used_names = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            used_names.add(node.id)
+        # Note: In type hints like `List[Optional[int]]`, `Optional` is a Name node in AST.
+
+    if 'Optional' in used_names:
+        print("Optional is USED.")
+    else:
+        print("Optional is NOT used.")
+
+if __name__ == "__main__":
+    check_unused_imports(sys.argv[1])


### PR DESCRIPTION
This PR removes unused imports (`Set` and `Optional`) from `studio/agents/product_owner.py`.
Tests passed locally. Static analysis confirmed `Optional` is unused.

---
*PR created automatically by Jules for task [18395421845654380318](https://jules.google.com/task/18395421845654380318) started by @jonaschen*