### PR TITLE
Clean up unused imports in entropy_math.py

### DIFF
--- a/studio/utils/entropy_math.py
+++ b/studio/utils/entropy_math.py
@@ -18,9 +18,6 @@ import math
 import logging
 import asyncio
 from typing import List, Dict, Tuple, Protocol
-from collections import Counter
-from pydantic import BaseModel
-
 # Import strict schema from the Studio Memory
 from studio.memory import SemanticHealthMetric
 


### PR DESCRIPTION
Removed unused imports `Counter` (from `collections`) and `BaseModel` (from `pydantic`) in `studio/utils/entropy_math.py` to improve code health. Verified that no regressions were introduced by running `tests/test_entropy_math.py`.

---
*PR created automatically by Jules for task [1365282765034082707](https://jules.google.com/task/1365282765034082707) started by @jonaschen*