### PR TITLE
Add Context Slicing Data Test and Log Chunking Logic

### DIFF
--- a/studio/memory.py
+++ b/studio/memory.py
@@ -214,6 +214,7 @@ class SOPState(BaseModel):
 class OrchestrationState(BaseModel):
     session_id: str
     user_intent: str
+    full_logs: str = Field(default="", description="The complete log file uploaded by the user")
     triage_status: Optional[TriageStatus] = None
     guidance_sop: Optional[SOPState] = None
     # The active context slice being processed

--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -264,12 +264,17 @@ class Orchestrator:
         # For now, we mock the slicing logic.
         relevant_files = {"drivers/gpu/msm/mdss.c": "void main() { ... }"}
 
+        # Extract the 'Event Horizon' (last 500 lines) - Fix #3
+        full_logs = state.orchestration.full_logs or ""
+        log_lines = full_logs.splitlines()
+        sliced_logs = "\n".join(log_lines[-500:]) if log_lines else ""
+
         # Create the Ephemeral Slice
         new_slice = ContextSlice(
             slice_id="slice_" + datetime.now().isoformat(),
             intent=intent if intent in ["DIAGNOSIS", "CODING", "REVIEW"] else "CODING",
             active_files=relevant_files,
-            relevant_logs="[1456.789] Panic at...", # Mock sliced log
+            relevant_logs=sliced_logs,
             constraints=["DO NOT modify outside of drivers/"]
         )
 

--- a/tests/test_context_slicing.py
+++ b/tests/test_context_slicing.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from studio.memory import (
+    StudioState, OrchestrationState, EngineeringState, TriageStatus,
+    SemanticHealthMetric, JulesMetadata, CodeChangeArtifact
+)
+from studio.orchestrator import Orchestrator
+
+# Set mock project to avoid Google Auth errors
+os.environ["GOOGLE_CLOUD_PROJECT"] = "mock-project"
+
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+def test_context_slicing_large_log(mock_gen_model, mock_vertex_judge):
+    """
+    測試目標： 驗證 Orchestrator 的 Context Slicing 邏輯是否生效 (特別是針對大檔案)。
+    情境： 用戶上傳了一個 100MB 的 Log 檔案。
+    """
+    # Create a log with many lines to test the 500 line limit.
+    # 10,000 lines.
+    log_content = "\n".join([f"Line {i}: Log message" for i in range(10000)])
+
+    orch_state = OrchestrationState(
+        session_id="test_slicing",
+        user_intent="UNKNOWN",
+        full_logs=log_content,
+        triage_status=TriageStatus(is_log_available=True, suspected_domain="drivers")
+    )
+    eng_state = EngineeringState()
+    state = StudioState(orchestration=orch_state, engineering=eng_state)
+
+    # Mock dependencies
+    mock_engineer_app = MagicMock()
+    mock_engineer_app.ainvoke = AsyncMock(return_value={
+        "jules_metadata": JulesMetadata(
+            status="COMPLETED",
+            generated_artifacts=[CodeChangeArtifact(diff_content="Patch applied.")]
+        )
+    })
+
+    orchestrator = Orchestrator(engineer_app=mock_engineer_app)
+
+    # Mock calculator
+    mock_metric = SemanticHealthMetric(
+        entropy_score=0.5,
+        threshold=7.0,
+        sample_size=5,
+        is_tunneling=False,
+        cluster_distribution={}
+    )
+    orchestrator.calculator.measure_uncertainty = AsyncMock(return_value=mock_metric)
+
+    # Run the graph
+    final_state = asyncio.run(orchestrator.app.ainvoke(state))
+
+    # Verify results
+    if isinstance(final_state, dict):
+        orch = final_state["orchestration"]
+    else:
+        orch = final_state.orchestration
+
+    if isinstance(orch, dict):
+        slice_obj = orch["current_context_slice"]
+    else:
+        slice_obj = orch.current_context_slice
+
+    assert slice_obj is not None
+
+    relevant_logs = slice_obj["relevant_logs"] if isinstance(slice_obj, dict) else slice_obj.relevant_logs
+
+    lines = relevant_logs.splitlines()
+    assert len(lines) == 500
+    assert lines[-1] == "Line 9999: Log message"
+    assert lines[0] == "Line 9500: Log message"


### PR DESCRIPTION
Implemented the "Context Slicing" logic in the Orchestrator to handle large log files by truncating them to the last 500 lines (Event Horizon). Added a new test suite `tests/test_context_slicing.py` to verify this behavior, ensuring that the engineering agent receives a manageable and relevant context slice even when the input log is very large (e.g., 100MB). Updated the `OrchestrationState` data model to support storage of the full log content.

Fixes #58

---
*PR created automatically by Jules for task [1184011954332603500](https://jules.google.com/task/1184011954332603500) started by @jonaschen*