### PR TITLE
Add 'Max Retry' Containment Test and escalation signal

### DIFF
--- a/studio/memory.py
+++ b/studio/memory.py
@@ -311,6 +311,7 @@ class StudioState(BaseModel):
     # Meta-Data
     system_version: str = "5.2.0"
     circuit_breaker_triggered: bool = False # Hard Stop for SE > 7.0 [cite: 733]
+    escalation_triggered: bool = False # Explicit signal for human intervention
 
     # Layers
     orchestration: OrchestrationState

--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -106,6 +106,7 @@ class Orchestrator:
 
             # 3. Process results
             jules_meta = result["jules_metadata"]
+            updates = {}
 
             proposed_patch = None
             if jules_meta.generated_artifacts:
@@ -117,6 +118,7 @@ class Orchestrator:
                 gate_status = "GREEN"
             elif jules_meta.status == "FAILED":
                 gate_status = "RED"
+                updates["escalation_triggered"] = True
 
             # 4. Enforce Semantic Entropy Guardrail
             # Real implementation using the actual calculator
@@ -129,8 +131,6 @@ class Orchestrator:
                 thought_process="Subgraph execution complete.",
                 cognitive_health=metric
             )
-
-            updates = {}
 
             # Map output back to StudioState
             if hasattr(state.engineering, "model_copy"):

--- a/tests/test_max_retry.py
+++ b/tests/test_max_retry.py
@@ -1,0 +1,135 @@
+import os
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from studio.memory import (
+    StudioState, OrchestrationState, EngineeringState, TriageStatus,
+    SemanticHealthMetric, JulesMetadata, CodeChangeArtifact, ContextSlice,
+    TestResult, ReviewVerdict, Violation
+)
+from studio.orchestrator import Orchestrator
+from studio.utils.jules_client import WorkStatus
+from studio.utils.sandbox import TestRunResult
+
+# Set mock project to avoid Google Auth errors
+os.environ["GOOGLE_CLOUD_PROJECT"] = "mock-project"
+
+@pytest.mark.asyncio
+async def test_max_retry_containment():
+    """
+    The "Max Retry" Containment Test (止損測試)
+    測試目標： 防止系統進入無限迴圈燒錢。
+    情境： AI 徹底卡關，怎麼修都修不好。
+    """
+
+    # 1. Setup Initial State
+    jules_meta = JulesMetadata(
+        session_id="max-retry-session",
+        max_retries=3,
+        status="QUEUED"
+    )
+
+    orch_state = OrchestrationState(
+        session_id="max-retry-session",
+        user_intent="CODING",
+        triage_status=TriageStatus(is_log_available=True, suspected_domain="app"),
+        current_context_slice=ContextSlice(intent="CODING", files=["src/app.py", "tests/test_app.py"])
+    )
+
+    eng_state = EngineeringState(
+        current_task="Fix impossible bug",
+        jules_meta=jules_meta
+    )
+
+    state = StudioState(
+        orchestration=orch_state,
+        engineering=eng_state
+    )
+
+    # 2. Mocking
+
+    with patch("studio.subgraphs.engineer.JulesGitHubClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.dispatch_task.return_value = "task-retry"
+        mock_client.get_status.return_value = WorkStatus(
+            tracking_id="task-retry",
+            status="COMPLETED",
+            raw_diff="Failing Diff",
+            pr_url="http://github.com/pr/retry"
+        )
+
+        low_entropy_metric = SemanticHealthMetric(
+            entropy_score=0.5,
+            threshold=7.0,
+            sample_size=5,
+            is_tunneling=False,
+            cluster_distribution={"Cluster_0": 1.0}
+        )
+
+        with patch("studio.subgraphs.engineer.SemanticEntropyCalculator.measure_uncertainty", new_callable=AsyncMock) as mock_measure_sub, \
+             patch("studio.orchestrator.SemanticEntropyCalculator.measure_uncertainty", new_callable=AsyncMock) as mock_measure_orch, \
+             patch("studio.subgraphs.engineer.ArchitectAgent"), \
+             patch("studio.subgraphs.engineer.VertexFlashJudge"), \
+             patch("studio.orchestrator.VertexFlashJudge"), \
+             patch("studio.subgraphs.engineer.GenerativeModel"), \
+             patch("studio.orchestrator.GenerativeModel"), \
+             patch("studio.subgraphs.engineer.DockerSandbox") as mock_sandbox_class, \
+             patch("studio.subgraphs.engineer.os.path.exists", return_value=True), \
+             patch("studio.subgraphs.engineer.open", MagicMock()), \
+             patch("studio.subgraphs.engineer.apply_virtual_patch") as mock_apply_patch:
+
+            mock_measure_sub.return_value = low_entropy_metric
+            mock_measure_orch.return_value = low_entropy_metric
+
+            mock_apply_patch.return_value = {"src/app.py": "code", "tests/test_app.py": "test"}
+
+            mock_sandbox_instance = mock_sandbox_class.return_value
+            mock_sandbox_instance.setup_workspace.return_value = True
+
+            # Always fail
+            fail_result = TestRunResult(
+                test_id="tests/test_app.py",
+                passed=False,
+                total_tests=1,
+                failed_tests=1,
+                error_log="AssertionError: Still failing",
+                duration_ms=100
+            )
+            # We expect 4 attempts total (retry_count: 0, 1, 2, 3)
+            mock_sandbox_instance.run_pytest.return_value = fail_result
+
+            # 3. Initialize Orchestrator and Run
+            orchestrator = Orchestrator()
+            # We use a try-except or just run it, but it might fail on pydantic validation if we add fields
+            final_state = await orchestrator.app.ainvoke(state)
+
+            # 4. Assertions
+            if isinstance(final_state, dict):
+                engineering = final_state.get("engineering")
+                if isinstance(engineering, dict):
+                    jules_meta = engineering.get("jules_meta")
+                else:
+                    jules_meta = engineering.jules_meta
+
+                # Check escalation_triggered flag
+                escalation_triggered = final_state.get("escalation_triggered", False)
+            else:
+                jules_meta = final_state.engineering.jules_meta
+                # This will fail until we add the field to StudioState
+                escalation_triggered = getattr(final_state, "escalation_triggered", False)
+
+            if isinstance(jules_meta, dict):
+                retry_count = jules_meta.get("retry_count")
+                status = jules_meta.get("status")
+            else:
+                retry_count = jules_meta.retry_count
+                status = jules_meta.status
+
+            # A. retry_count 應該達到 max_retries (3)
+            assert retry_count == 3
+
+            # B. 最終狀態應為 FAILED
+            assert status == "FAILED"
+
+            # C. 應該觸發 Escalation 訊號
+            assert escalation_triggered is True


### PR DESCRIPTION
Implemented the 'Max Retry' Containment Test and escalation signaling logic as requested. Added a new test file `tests/test_max_retry.py` and updated `StudioState` and `Orchestrator` to handle the escalation signal when an engineering task fails after maximum retries.

Fixes #57

---
*PR created automatically by Jules for task [10710164692275039089](https://jules.google.com/task/10710164692275039089) started by @jonaschen*