### PR TITLE
🧹 Remove unused Union import from jules_client.py

### DIFF
--- a/studio/utils/jules_client.py
+++ b/studio/utils/jules_client.py
@@ -15,7 +15,7 @@ Dependencies:
 """
 
 import logging
-from typing import Protocol, List, Dict, Optional, Literal, Union
+from typing import Protocol, List, Dict, Optional, Literal
 from enum import Enum
 from pydantic import BaseModel, Field, SecretStr
 


### PR DESCRIPTION
Removed unused Union import from studio/utils/jules_client.py

---
*PR created automatically by Jules for task [11177456916072999432](https://jules.google.com/task/11177456916072999432) started by @jonaschen*