### PR TITLE
🧹 Remove unused imports in studio/manager.py

### DIFF
--- a/studio/manager.py
+++ b/studio/manager.py
@@ -3,7 +3,6 @@ import json
 import shutil
 import tempfile
 from typing import Any, Dict
-from datetime import datetime, timezone
 from studio.memory import (
     StudioState, OrchestrationState, EngineeringState, VerificationGate
 )


### PR DESCRIPTION
🎯 **What:** Removed unused imports `datetime` and `timezone` from `studio/manager.py`.
💡 **Why:** Code health improvement. These imports were not used in the file, cluttering the code.
✅ **Verification:** Verified by running `tests/studio_golden/test_manager_core.py`.
✨ **Result:** Cleaner code in `studio/manager.py`.

---
*PR created automatically by Jules for task [7658411140811901865](https://jules.google.com/task/7658411140811901865) started by @jonaschen*