### PR TITLE
🧹 Remove unused import shutil from studio/utils/patching.py

### DIFF
--- a/studio/utils/patching.py
+++ b/studio/utils/patching.py
@@ -8,7 +8,6 @@ Used by the QA Agent to prepare the sandbox environment.
 import os
 import tempfile
 import subprocess
-import shutil
 import logging
 from typing import Dict, List, Optional
 


### PR DESCRIPTION
Removed the unused `shutil` import from `studio/utils/patching.py` to improve code cleanliness. Verified that `shutil` is not used in the file and that relevant tests pass.

---
*PR created automatically by Jules for task [7300897466462123909](https://jules.google.com/task/7300897466462123909) started by @jonaschen*