### PR TITLE
🧹 Remove unused Optional import in scrum_master.py

### DIFF
--- a/studio/agents/scrum_master.py
+++ b/studio/agents/scrum_master.py
@@ -15,7 +15,7 @@ Dependencies:
 """
 
 import logging
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Any
 from pydantic import BaseModel, Field
 
 from langchain_google_vertexai import ChatVertexAI


### PR DESCRIPTION
This PR addresses a code health issue in `studio/agents/scrum_master.py` by removing the unused `Optional` import.

**Changes:**
- Removed `Optional` from `from typing import ...`

**Verification:**
- Verified via manual inspection and `grep` that `Optional` is unused.
- Ran `tests/test_scrum_master.py` and all tests passed.
- Code review requested restoring `pydantic` imports (which were also unused) to be safe, which was done.

---
*PR created automatically by Jules for task [3802133102817021012](https://jules.google.com/task/3802133102817021012) started by @jonaschen*