### PR TITLE
🧹 Clean up unused imports in studio/agents/architect.py

### DIFF
--- a/studio/agents/architect.py
+++ b/studio/agents/architect.py
@@ -17,15 +17,14 @@ Dependencies:
 
 import logging
 import hashlib
-from typing import List, Optional, Literal, Dict, Any
-from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
 
 from langchain_google_vertexai import ChatVertexAI
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import PydanticOutputParser
 
 # Import Memory Schema
-from studio.memory import ArchitecturalDecisionRecord, Violation, ReviewVerdict
+from studio.memory import Violation, ReviewVerdict
 
 logger = logging.getLogger("studio.agents.architect")
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports (`Literal`, `List`, `BaseModel`, `Field`, `ArchitecturalDecisionRecord`) from `studio/agents/architect.py`.
💡 **Why:** To improve code maintainability and cleanliness by removing dead code.
✅ **Verification:**
- Ran `pylint studio/agents/architect.py`: Rating improved from 3.28 to 7.14, no unused import warnings.
- Ran `PYTHONPATH=. python3 -m pytest tests/test_architect_agent.py`: 3 tests passed.
✨ **Result:** A cleaner `studio/agents/architect.py` file with no unused imports.

---
*PR created automatically by Jules for task [11358112549921367026](https://jules.google.com/task/11358112549921367026) started by @jonaschen*