### PR TITLE
🧹 Remove unused import in studio/subgraphs/engineer.py

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -29,7 +29,6 @@ from vertexai.generative_models import GenerativeModel
 from studio.utils.entropy_math import SemanticEntropyCalculator, VertexFlashJudge
 from studio.utils.sandbox import DockerSandbox
 from studio.utils.patching import apply_virtual_patch
-from studio.utils.prompts import ENGINEER_SYSTEM_PROMPT
 from studio.agents.architect import ArchitectAgent, ReviewVerdict
 
 logger = logging.getLogger("JulesProxy")


### PR DESCRIPTION
Removed `ENGINEER_SYSTEM_PROMPT` import from `studio/subgraphs/engineer.py` as it was unused.
Verified that the engineer subgraph still works correctly by running relevant tests.

---
*PR created automatically by Jules for task [1524405051721919088](https://jules.google.com/task/1524405051721919088) started by @jonaschen*