### PR TITLE
Refactor ReviewAgent JSON parsing for robustness

### DIFF
--- a/tests/test_review_agent_parsing.py
+++ b/tests/test_review_agent_parsing.py
@@ -1,7 +1,6 @@
 import unittest
 import sys
 import os
-import re
 from unittest.mock import MagicMock
 
 # Mock dependencies before importing studio.review_agent
@@ -31,10 +30,9 @@ from studio.review_agent import ReviewAgent, ReviewAgentOutputError
 
 class TestReviewAgentParsing(unittest.TestCase):
     def setUp(self):
-        # We need to mock os.environ temporarily for init
+        # Mock env vars
         with unittest.mock.patch.dict(os.environ, {"PROJECT_ID": "test-project"}):
             self.agent = ReviewAgent()
-            # Disable actual LLM just in case, though imports are mocked
             self.agent.llm = MagicMock()
 
     def test_valid_json(self):
@@ -76,8 +74,8 @@ Hope this helps!
         self.assertEqual(result["status"], "PASSED")
         self.assertEqual(result["root_cause"], "Good job")
 
-    def test_multiple_braces(self):
-        """Test parsing when input contains multiple braces (nested JSON)."""
+    def test_nested_json(self):
+        """Test parsing when input contains nested JSON objects."""
         raw_text = """
 {
   "status": "FAILED",
@@ -93,6 +91,43 @@ Hope this helps!
         self.assertEqual(result["status"], "FAILED")
         self.assertIsInstance(result["details"], dict)
         self.assertEqual(result["details"]["line"], 10)
+
+    def test_braces_in_conversational_text_with_markdown(self):
+        """Test parsing when conversational text contains braces, followed by markdown JSON."""
+        # This case exposes the greedy regex issue if not handled correctly.
+        # The greedy regex '({.*})' will capture from first { to last }.
+        raw_text = """
+The code contains a function `def foo(x): return {x}` which is fine.
+Here is the review result:
+```json
+{
+  "status": "PASSED",
+  "root_cause": "No issues found",
+  "suggested_fix": "N/A"
+}
+```
+"""
+        # Expected behavior: The JSON inside ```json ... ``` should be extracted.
+        # If greedy regex captures `return {x} ... { ... }`, json.loads will fail.
+        result = self.agent._clean_and_parse_json(raw_text)
+        self.assertEqual(result["status"], "PASSED")
+
+    def test_braces_in_conversational_text_no_markdown(self):
+        """Test parsing when conversational text contains braces, followed by raw JSON (no markdown)."""
+        # This is a harder case.
+        raw_text = """
+The code contains a function `def foo(x): return {x}` which is fine.
+Here is the review result:
+{
+  "status": "PASSED",
+  "root_cause": "No issues found",
+  "suggested_fix": "N/A"
+}
+"""
+        # If greedy regex captures `return {x} ... { ... }`, json.loads will fail.
+        # We expect this to be robustly handled.
+        result = self.agent._clean_and_parse_json(raw_text)
+        self.assertEqual(result["status"], "PASSED")
 
     def test_malformed_json(self):
         """Test that malformed JSON raises ReviewAgentOutputError."""
@@ -114,26 +149,6 @@ Hope this helps!
         self.assertEqual(result["status"], "PASSED")
         self.assertEqual(result["root_cause"], "LGTM")
         self.assertTrue(result["approved"])
-
-    def test_greedy_regex_issue(self):
-        """Test potential issue with greedy regex matching across multiple JSON blocks."""
-        # This test is designed to fail if the regex is too greedy and captures multiple objects as one
-        raw_text = """
-Block 1:
-{ "id": 1 }
-Block 2:
-{ "id": 2 }
-"""
-        # The current implementation uses re.DOTALL which makes . match newlines.
-        # It matches from first { to last }.
-        # So it will extract:
-        # { "id": 1 }
-        # Block 2:
-        # { "id": 2 }
-        # This is invalid JSON.
-
-        with self.assertRaises(ReviewAgentOutputError):
-             self.agent._clean_and_parse_json(raw_text)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR improves the robustness of JSON parsing in `ReviewAgent`. Previously, a greedy regex caused failures when the LLM output contained conversational text with braces (e.g., code snippets) alongside the JSON result. The new implementation scans the entire output for valid JSON objects and selects the most relevant one based on a scoring heuristic (presence of expected keys).

A new test file `tests/test_review_agent_parsing.py` has been added to cover various scenarios, including the specific edge case that caused failures. Existing tests in `tests/test_review_agent.py` also pass.

---
*PR created automatically by Jules for task [16450762637327053806](https://jules.google.com/task/16450762637327053806) started by @jonaschen*