### PR TITLE
Fix robust virtual patch application in engineer subgraph

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -28,7 +28,7 @@ from studio.utils.jules_client import JulesGitHubClient, TaskPayload, WorkStatus
 from vertexai.generative_models import GenerativeModel
 from studio.utils.entropy_math import SemanticEntropyCalculator, VertexFlashJudge
 from studio.utils.sandbox import DockerSandbox
-from studio.utils.patching import apply_virtual_patch
+from studio.utils.patching import apply_virtual_patch, extract_affected_files
 from studio.agents.architect import ArchitectAgent, ReviewVerdict
 from studio.config import get_settings
 
@@ -286,25 +286,35 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
     files_to_patch = {}
     test_files = []
 
-    # Identify files from context slice
+    # Identify files to load
+    files_to_load = set()
+
+    # 1. From context slice
     if jules_data.active_context_slice and jules_data.active_context_slice.files:
         for filepath in jules_data.active_context_slice.files:
-            try:
-                # In a real deployment, we'd fetch these from the repo
-                if os.path.exists(filepath):
-                    with open(filepath, "r", encoding="utf-8") as f:
-                        files_to_patch[filepath] = f.read()
+            files_to_load.add(filepath)
+            # Assume tests are in 'tests/' directory or similar
+            if "test" in filepath or "spec" in filepath:
+                test_files.append(filepath)
 
-                # Assume tests are in 'tests/' directory or similar
-                if "test" in filepath or "spec" in filepath:
-                    test_files.append(filepath)
-            except FileNotFoundError:
-                logger.warning(f"Context file not found: {filepath}")
-
-    # Get the diff
+    # 2. From the diff itself (Dynamic discovery)
     diff_content = ""
     if jules_data.generated_artifacts:
         diff_content = jules_data.generated_artifacts[0].diff_content
+        affected_files = extract_affected_files(diff_content)
+        for filepath in affected_files:
+            files_to_load.add(filepath)
+
+    # Load file contents from disk
+    for filepath in files_to_load:
+        try:
+            if os.path.exists(filepath):
+                with open(filepath, "r", encoding="utf-8") as f:
+                    files_to_patch[filepath] = f.read()
+            else:
+                logger.info(f"File {filepath} not found on disk, assuming it is a new file.")
+        except Exception as e:
+            logger.warning(f"Failed to load file {filepath}: {e}")
 
     # Apply Patch
     try:
@@ -402,18 +412,26 @@ async def node_architect_gate(state: AgentState) -> Dict[str, Any]:
 
     # 1. Reconstruct Context (Patched Code)
     files_to_patch = {}
+    files_to_load = set()
+
     if jules_data.active_context_slice and jules_data.active_context_slice.files:
         for filepath in jules_data.active_context_slice.files:
-            try:
-                if os.path.exists(filepath):
-                    with open(filepath, "r", encoding="utf-8") as f:
-                        files_to_patch[filepath] = f.read()
-            except FileNotFoundError:
-                pass
+            files_to_load.add(filepath)
 
     diff_content = ""
     if jules_data.generated_artifacts:
         diff_content = jules_data.generated_artifacts[0].diff_content
+        affected_files = extract_affected_files(diff_content)
+        for filepath in affected_files:
+            files_to_load.add(filepath)
+
+    for filepath in files_to_load:
+        try:
+            if os.path.exists(filepath):
+                with open(filepath, "r", encoding="utf-8") as f:
+                    files_to_patch[filepath] = f.read()
+        except Exception:
+            pass
 
     try:
         patched_files = apply_virtual_patch(files_to_patch, diff_content)

--- a/studio/utils/jules_client.py
+++ b/studio/utils/jules_client.py
@@ -185,7 +185,16 @@ class JulesGitHubClient:
                         fixed_patch.append(' ' + line)
 
                 patch_content = "\n".join(fixed_patch) + "\n"
-                diff_parts.append(f"--- a/{f.filename}\n+++ b/{f.filename}\n{patch_content}")
+
+                # Determine header based on status
+                if f.status == "added":
+                    header = f"--- /dev/null\n+++ b/{f.filename}\n"
+                elif f.status == "removed":
+                    header = f"--- a/{f.filename}\n+++ /dev/null\n"
+                else:
+                    header = f"--- a/{f.filename}\n+++ b/{f.filename}\n"
+
+                diff_parts.append(header + patch_content)
 
             diff_text = "".join(diff_parts)
 

--- a/tests/test_jules_client_diff.py
+++ b/tests/test_jules_client_diff.py
@@ -56,3 +56,45 @@ def test_get_status_constructs_correct_diff(mock_github):
     assert "\n line1\n" in status.raw_diff
     assert "\n \n" in status.raw_diff  # The empty line became a space
     assert "\n line3\n" in status.raw_diff # line3 got its space
+
+def test_get_status_handles_added_removed_files(mock_github):
+    client = JulesGitHubClient(github_token=SecretStr("fake_token"), repo_name="owner/repo")
+    mock_repo = MagicMock()
+    client._repo_cache = mock_repo
+    mock_issue = MagicMock()
+    mock_repo.get_issue.return_value = mock_issue
+
+    # Mock timeline to find linked PR
+    mock_event = MagicMock()
+    mock_event.event = "cross-referenced"
+    mock_event.source.issue.pull_request = True
+    mock_pr = MagicMock()
+    mock_pr.number = 456
+    mock_pr.state = "open"
+    mock_pr.html_url = "http://github.com/owner/repo/pull/456"
+    mock_pr.head.sha = "abcdef12345"
+    mock_pr.additions = 1
+    mock_pr.deletions = 1
+    mock_event.source.issue.as_pull_request.return_value = mock_pr
+    mock_issue.get_timeline.return_value = [mock_event]
+
+    # Added file
+    f_added = MagicMock()
+    f_added.filename = "new.py"
+    f_added.status = "added"
+    f_added.patch = "@@ -0,0 +1 @@\n+print('new')"
+
+    # Removed file
+    f_removed = MagicMock()
+    f_removed.filename = "old.py"
+    f_removed.status = "removed"
+    f_removed.patch = "@@ -1 +0,0 @@\n-print('old')"
+
+    mock_pr.get_files.return_value = [f_added, f_removed]
+
+    # Execute
+    status = client.get_status("123")
+
+    # Verify headers
+    assert "--- /dev/null\n+++ b/new.py" in status.raw_diff
+    assert "--- a/old.py\n+++ /dev/null" in status.raw_diff

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -81,8 +81,8 @@ def test_apply_patch_failure():
             apply_virtual_patch(files, diff)
 
         assert "Failed to apply patch" in str(excinfo.value)
-        # Should have tried twice (-p1 then -p0)
-        assert mock_run.call_count == 2
+        # Should have tried once (only -p1)
+        assert mock_run.call_count == 1
 
 def test_patch_command_not_found():
     files = {"file.py": "content"}
@@ -96,27 +96,6 @@ def test_patch_command_not_found():
 
         assert "patch command not found" in str(excinfo.value)
 
-def test_apply_patch_p0_fallback():
-    files = {"file.py": "content"}
-    diff = "diff"
-
-    with unittest.mock.patch("subprocess.run") as mock_run:
-        # First call (-p1) fails, second call (-p0) succeeds
-        mock_run.side_effect = [
-            MagicMock(returncode=1, stderr="hunk failed"),
-            MagicMock(returncode=0)
-        ]
-
-        # Since we mock success but don't actually modify files on disk (mocked subprocess),
-        # the result will be the original files. This is expected in this mock scenario.
-        # We are testing the fallback logic here.
-        apply_virtual_patch(files, diff)
-
-        assert mock_run.call_count == 2
-        # Check second call arguments
-        args, kwargs = mock_run.call_args_list[1]
-        cmd = args[0]
-        assert "-p0" in cmd
 
 def test_apply_patch_malformed_resilience():
     files = {"hello.py": "print('hello')\n\nprint('world')\n"}


### PR DESCRIPTION
The virtual patching process was failing during automated feedback loops because the `node_qa_verifier` and `node_architect_gate` only provided the `apply_virtual_patch` utility with files from the initial `context_slice`. If the agent's generated diff touched other files (like `requirements.txt`), the `patch` command would fail. 

This PR fixes the issue by:
1. Dynamically extracting all file paths from the generated diff using a new `extract_affected_files` utility.
2. Ensuring all these files are loaded from the filesystem and included in the patching context.
3. Standardizing on `-p1` patching by removing a problematic `-p0` fallback that could create incorrect directory structures.
4. Enhancing `JulesGitHubClient` to produce more standard unified diffs for added and removed files.

Verified with a reproduction script and updated unit tests.

Fixes #124

---
*PR created automatically by Jules for task [13309532706211455833](https://jules.google.com/task/13309532706211455833) started by @jonaschen*