### PR TITLE
Fix Sandbox Teardown AttributeError

### DIFF
--- a/studio/utils/sandbox.py
+++ b/studio/utils/sandbox.py
@@ -84,13 +84,16 @@ class DockerSandbox:
     A disposable Docker container for running untrusted AI code.
     """
     def __init__(self, image: str = "python:3.10-slim", timeout_sec: int = 60):
+        # Initialize attributes to None first to avoid AttributeError during teardown if init fails
+        self.client = None
+        self.container = None
+
         if not docker:
             raise ImportError("Docker SDK not found. Run `pip install docker`.")
 
         self.client = docker.from_env()
         self.image = image
         self.timeout = timeout_sec
-        self.container: Optional[Container] = None
         self._start_container()
 
     def _start_container(self):


### PR DESCRIPTION
This PR fixes a bug where `DockerSandbox` would throw an `AttributeError: 'DockerSandbox' object has no attribute 'container'` during teardown if the `__init__` method failed before `self.container` was initialized.

The fix involves moving the initialization of `self.client` and `self.container` to the very beginning of the `__init__` method, ensuring they are always present when `teardown()` (and consequently `__del__`) is called.

Fixes #138

---
*PR created automatically by Jules for task [11320757348730758708](https://jules.google.com/task/11320757348730758708) started by @jonaschen*