### PR TITLE
Implement robust Docker connectivity handling in DockerSandbox

### DIFF
--- a/studio/utils/sandbox.py
+++ b/studio/utils/sandbox.py
@@ -91,7 +91,16 @@ class DockerSandbox:
         if not docker:
             raise ImportError("Docker SDK not found. Run `pip install docker`.")
 
-        self.client = docker.from_env()
+        try:
+            # Robust daemon connectivity handling
+            self.client = docker.from_env()
+            # Verify connectivity immediately to catch permission errors or daemon issues
+            self.client.ping()
+        except Exception as e:
+            logger.error(f"Docker connection failed: {e}")
+            # Raise a cleaner error for the QA Agent feedback loop
+            raise RuntimeError(f"Docker Sandbox unavailable: {e}")
+
         self.image = image
         self.timeout = timeout_sec
         self._start_container()

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -136,3 +136,27 @@ test_foo.py::test_3 FAILED
         # Assert
         mock_container.stop.assert_called_once()
         assert sandbox.container is None
+
+    def test_init_fails_on_permission_error(self, mock_client):
+        # Arrange
+        error_msg = "Error while fetching server API version: Permission denied"
+        with patch("studio.utils.sandbox.docker.from_env") as mock_from_env:
+             mock_from_env.side_effect = Exception(error_msg)
+
+             # Act & Assert
+             with pytest.raises(RuntimeError) as excinfo:
+                 DockerSandbox()
+
+             assert "Docker Sandbox unavailable" in str(excinfo.value)
+             assert "Permission denied" in str(excinfo.value)
+
+    def test_init_fails_on_ping_error(self, mock_client):
+        # Arrange
+        mock_client.ping.side_effect = Exception("Daemon unreachable")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError) as excinfo:
+            DockerSandbox()
+
+        assert "Docker Sandbox unavailable" in str(excinfo.value)
+        assert "Daemon unreachable" in str(excinfo.value)


### PR DESCRIPTION
Implemented robust Docker connectivity handling in `DockerSandbox` to address `PermissionError(13, 'Permission denied')` during initialization. The fix involves wrapping the Docker client creation and calling `ping()` immediately to catch connection issues early, raising a descriptive `RuntimeError` that can be captured by the QA feedback loop. Consolidated resilience tests into `tests/test_sandbox.py`.

Fixes #142

---
*PR created automatically by Jules for task [12545475986756985055](https://jules.google.com/task/12545475986756985055) started by @jonaschen*