### PR TITLE
Standardize Semantic Entropy Threshold to 2.0

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,7 @@ stateDiagram-v2
 
     EngineerSubgraph --> BacklogDispatcher: Task Success/Fail
 
-    EngineerSubgraph --> Reflector: SE > 7.0 (Breaker)
+    EngineerSubgraph --> Reflector: SE > 2.0 (Breaker)
     Reflector --> [*]: Circuit Breaker Triggered
 
     ScrumMaster --> Optimizer: Report Generated
@@ -159,8 +159,8 @@ stateDiagram-v2
     WatchTower --> HumanInterrupt: Status = BLOCKED (if enabled)
 
     state EntropyGuard <<choice>>
-    EntropyGuard --> FeedbackLoop: SE > 7.0 (Tunneling) or Status=FAILED
-    EntropyGuard --> QAVerifier: SE < 7.0 (Healthy) & Status=VERIFYING
+    EntropyGuard --> FeedbackLoop: SE > 2.0 (Tunneling) or Status=FAILED
+    EntropyGuard --> QAVerifier: SE < 2.0 (Healthy) & Status=VERIFYING
 
     QAVerifier --> ArchitectGate: Tests PASS
     QAVerifier --> FeedbackLoop: Tests FAIL

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The system operates as a **Hierarchical State Machine** orchestrated by LangGrap
 ### Key Features
 *   **Optimization by PROmpting (OPRO):** The system self-corrects its own instructions (`prompts.json`) based on retrospective analysis, allowing it to "learn" from mistakes.
 *   **Interactive Debugging (SOP Guide):** A logical subgraph (within the Orchestrator) for handling "No-Log" scenarios where the user needs guidance to extract data before analysis can begin.
-*   **Semantic Entropy Guardrail:** Uses `VertexFlashJudge` to measure the uncertainty of agent outputs. If entropy (SE) exceeds 7.0, the "Circuit Breaker" triggers to prevent compounding errors and "Cognitive Tunneling".
+*   **Semantic Entropy Guardrail:** Uses `VertexFlashJudge` to measure the uncertainty of agent outputs. If entropy (SE) exceeds 2.0, the "Circuit Breaker" triggers to prevent compounding errors and "Cognitive Tunneling".
 *   **Context Slicing:** Dynamically filters the file system and logs presented to each agent (Event Horizon), ensuring they only see what is relevant to their current task to prevent context collapse.
 *   **Evolution Safety Levels (ESL):**
     *   **ESL-1 (Product):** Automatic evolution of the product (prompts/code) via the Optimizer.

--- a/studio/memory.py
+++ b/studio/memory.py
@@ -23,7 +23,7 @@ class SemanticHealthMetric(BaseModel):
     Ref: [cite: 722]
     """
     entropy_score: float = Field(..., description="Calculated uncertainty (0.0 - 10.0)")
-    threshold: float = 7.0
+    threshold: float = 2.0
     sample_size: int = Field(default=5, description="Number of parallel generations")
     is_tunneling: bool = Field(..., description="True if entropy_score > threshold")
     cluster_distribution: Dict[str, float] = Field(default={}, description="Distribution of semantic meanings")
@@ -43,11 +43,11 @@ class SemanticEntropyReading(BaseModel):
     A specific measurement of the agent's cognitive uncertainty.
     Used by the Entropy_Guard node to detect 'Cognitive Tunneling'.
 
-    Research Threshold: SE > 7.0 typically indicates hallucination or
+    Research Threshold: SE > 2.0 typically indicates hallucination or
     reasoning loop collapse.
     """
     score: float = Field(..., ge=0.0, description="The calculated entropy score (SE)")
-    threshold: float = Field(default=7.0, description="The breaker threshold at time of reading")
+    threshold: float = Field(default=2.0, description="The breaker threshold at time of reading")
     triggered_breaker: bool = Field(..., description="Whether this reading forced an interruption")
     context_hash: str = Field(..., description="Hash of the context slice used for this generation")
     reasoning_trace_summary: Optional[str] = Field(None, description="Summary of thoughts analyzed")
@@ -302,7 +302,7 @@ class StudioState(BaseModel):
     """
     # Meta-Data
     system_version: str = "5.2.0"
-    circuit_breaker_triggered: bool = False # Hard Stop for SE > 7.0 [cite: 733]
+    circuit_breaker_triggered: bool = False # Hard Stop for SE > 2.0 [cite: 733]
     escalation_triggered: bool = False # Explicit signal for human intervention
 
     # Layers

--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -47,7 +47,7 @@ def engineer_subgraph_node(state: ContextSlice) -> Dict:
         "thought_process": "Analyzed dependencies and applied fix.",
         "cognitive_health": {
             "entropy_score": 0.5,
-            "threshold": 7.0,
+            "threshold": 2.0,
             "sample_size": 5,
             "is_tunneling": False,
             "cluster_distribution": {}

--- a/studio/rules.md
+++ b/studio/rules.md
@@ -73,7 +73,7 @@ return Tavily.search(query)
 ### 4.2 Semantic Entropy Guardrail
 * **Context:** When an agent hallucinates or is unsure, its output uncertainty (Semantic Entropy) spikes.
 
-* **Rule:** If Semantic Entropy > 7.0 (or confidence score < 0.3), reject the output immediately.
+* **Rule:** If Semantic Entropy > 2.0 (or confidence score < 0.3), reject the output immediately.
 
 * **Action:**
 

--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -275,7 +275,7 @@ async def node_entropy_guard(state: AgentState) -> Dict[str, Any]:
 
     Responsibilities:
     1. Calculates Semantic Entropy (SE) on the agent's reasoning trace.
-    2. Triggers the 'Circuit Breaker' if SE > 7.0.
+    2. Triggers the 'Circuit Breaker' if SE > 2.0.
     3. Prevents invalid code from reaching the QA stage.
     """
     jules_data = state["jules_metadata"]

--- a/tests/test_architect_veto.py
+++ b/tests/test_architect_veto.py
@@ -72,7 +72,7 @@ async def test_architect_veto():
         # Mock Entropy Calculator to return LOW ENTROPY
         low_entropy_metric = SemanticHealthMetric(
             entropy_score=0.5,
-            threshold=7.0,
+            threshold=2.0,
             sample_size=5,
             is_tunneling=False,
             cluster_distribution={"Cluster_0": 1.0}

--- a/tests/test_cognitive_tunneling.py
+++ b/tests/test_cognitive_tunneling.py
@@ -74,8 +74,8 @@ async def test_cognitive_tunneling_interception():
 
         # Mock Entropy Calculator to return HIGH ENTROPY
         high_entropy_metric = SemanticHealthMetric(
-            entropy_score=8.5,
-            threshold=7.0,
+            entropy_score=2.5,
+            threshold=2.0,
             sample_size=5,
             is_tunneling=True,
             cluster_distribution={"Cluster_0": 0.2, "Cluster_1": 0.2, "Cluster_2": 0.2, "Cluster_3": 0.2, "Cluster_4": 0.2}
@@ -135,10 +135,10 @@ async def test_cognitive_tunneling_interception():
             # If history items are dicts
             first_record = entropy_history[0]
             if isinstance(first_record, dict):
-                assert first_record.get("score") == 8.5
+                assert first_record.get("score") == 2.5
                 assert first_record.get("triggered_breaker") is True
             else:
-                assert first_record.score == 8.5
+                assert first_record.score == 2.5
                 assert first_record.triggered_breaker is True
 
             # D. 流程 不應該 進入 QA_Verifier (DockerSandbox should not be called)

--- a/tests/test_context_slicing.py
+++ b/tests/test_context_slicing.py
@@ -50,7 +50,7 @@ def test_context_slicing_large_log(mock_run_retrospective, mock_run_po, mock_gen
     # Mock calculator
     mock_metric = SemanticHealthMetric(
         entropy_score=0.5,
-        threshold=7.0,
+        threshold=2.0,
         sample_size=5,
         is_tunneling=False,
         cluster_distribution={}

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -73,7 +73,7 @@ async def test_escalation_logic():
 
         low_entropy_metric = SemanticHealthMetric(
             entropy_score=0.5,
-            threshold=7.0,
+            threshold=2.0,
             sample_size=5,
             is_tunneling=False,
             cluster_distribution={"Cluster_0": 1.0}

--- a/tests/test_lifecycle_manager.py
+++ b/tests/test_lifecycle_manager.py
@@ -47,7 +47,7 @@ def test_orchestrator_lifecycle_manager(mock_run_retrospective, mock_run_po, moc
     orchestrator = Orchestrator(engineer_app=mock_engineer_app)
     mock_metric = SemanticHealthMetric(
         entropy_score=0.5,
-        threshold=7.0,
+        threshold=2.0,
         sample_size=5,
         is_tunneling=False,
         cluster_distribution={}

--- a/tests/test_max_retry.py
+++ b/tests/test_max_retry.py
@@ -63,7 +63,7 @@ async def test_max_retry_containment():
 
         low_entropy_metric = SemanticHealthMetric(
             entropy_score=0.5,
-            threshold=7.0,
+            threshold=2.0,
             sample_size=5,
             is_tunneling=False,
             cluster_distribution={"Cluster_0": 1.0}

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -42,7 +42,7 @@ def test_orchestrator_coding_flow(mock_run_retrospective, mock_run_po, mock_gen_
     # Mock the calculator to avoid network calls and return a safe metric
     mock_metric = SemanticHealthMetric(
         entropy_score=0.5,
-        threshold=7.0,
+        threshold=2.0,
         sample_size=5,
         is_tunneling=False,
         cluster_distribution={}
@@ -77,7 +77,7 @@ def test_orchestrator_coding_flow(mock_run_retrospective, mock_run_po, mock_gen_
          assert eng.proposed_patch == "Patch applied."
          # assert orch.latest_entropy == 0.5 # Removed
 
-    # Check Circuit Breaker (Should be False as entropy is 0.5 < 7.0)
+    # Check Circuit Breaker (Should be False as entropy is 0.5 < 2.0)
     assert not cb
 
 @patch("studio.orchestrator.VertexFlashJudge")

--- a/tests/test_refactor_loop.py
+++ b/tests/test_refactor_loop.py
@@ -79,7 +79,7 @@ async def test_refactor_loop():
     # Mock Entropy Calculator to return LOW ENTROPY
     low_entropy_metric = SemanticHealthMetric(
         entropy_score=0.5,
-        threshold=7.0,
+        threshold=2.0,
         sample_size=5,
         is_tunneling=False,
         cluster_distribution={"Cluster_0": 1.0}

--- a/tests/test_router_diversion.py
+++ b/tests/test_router_diversion.py
@@ -44,7 +44,7 @@ async def test_router_case_a_coding_with_log(mock_gen_model, mock_vertex_judge):
     # Mock the calculator to avoid network calls
     mock_metric = SemanticHealthMetric(
         entropy_score=0.5,
-        threshold=7.0,
+        threshold=2.0,
         sample_size=5,
         is_tunneling=False,
         cluster_distribution={}

--- a/tests/test_tdd_loop.py
+++ b/tests/test_tdd_loop.py
@@ -65,7 +65,7 @@ async def test_red_green_refactor_loop():
         # Mock Entropy Calculator to return LOW ENTROPY
         low_entropy_metric = SemanticHealthMetric(
             entropy_score=0.5,
-            threshold=7.0,
+            threshold=2.0,
             sample_size=5,
             is_tunneling=False,
             cluster_distribution={"Cluster_0": 1.0}


### PR DESCRIPTION
Standardized the Semantic Entropy (SE) threshold to 2.0 across core logic, configuration, documentation, and tests to ensure the cognitive circuit breaker triggers correctly for N=5 samples.

Fixes #157

---
*PR created automatically by Jules for task [10033044617661594837](https://jules.google.com/task/10033044617661594837) started by @jonaschen*