### PR TITLE
Fix pytest ModuleNotFoundError for 'studio' package

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+pythonpath = .
+
 markers =
     integration: mark test as an integration test.
     slow: mark test as slow.


### PR DESCRIPTION
The fix involves adding `pythonpath = .` to `pytest.ini`. This allows `pytest` to automatically add the project root to `sys.path`, enabling it to find the `studio` and `product` packages. This resolved the `ModuleNotFoundError` that was causing 10 test files to fail during collection. I verified the fix by unsetting `PYTHONPATH` and running `pytest` directly, ensuring it can now collect and run tests successfully. All 122 tests in the repository passed after the change.

Fixes #159

---
*PR created automatically by Jules for task [18149908870750654009](https://jules.google.com/task/18149908870750654009) started by @jonaschen*