### PR TITLE
Ensure pytest.ini availability in sandbox and refine test filtering

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -365,6 +365,10 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
     if jules_data.active_context_slice and jules_data.active_context_slice.files:
         all_target_files.update(jules_data.active_context_slice.files)
 
+    # Ensure pytest.ini is included in the sandbox context if it exists locally
+    if os.path.exists("pytest.ini"):
+        all_target_files.add("pytest.ini")
+
     # 2. Get the diff and extract ALL affected files (Dynamic Context Sync)
     diff_content = ""
     if jules_data.generated_artifacts:
@@ -380,8 +384,8 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
                 with open(filepath, "r", encoding="utf-8") as f:
                     files_to_patch[filepath] = f.read()
 
-            # Identify tests to run
-            if "test" in filepath or "spec" in filepath:
+            # Identify tests to run (Must be .py files)
+            if (".py" in filepath) and ("test" in filepath or "spec" in filepath):
                 test_files.append(filepath)
         except FileNotFoundError:
             logger.warning(f"File not found during sandbox prep: {filepath}")

--- a/studio/utils/patching.py
+++ b/studio/utils/patching.py
@@ -91,19 +91,8 @@ def apply_virtual_patch(files: Dict[str, str], diff_content: str) -> Dict[str, s
             )
 
             if result.returncode != 0:
-                logger.warning(f"Patch failed with -p1: {result.stderr or result.stdout}")
-                # Fallback? Maybe -p0?
-                cmd[1] = "-p0"
-                result = subprocess.run(
-                    cmd,
-                    cwd=tmpdir,
-                    capture_output=True,
-                    text=True,
-                    check=False
-                )
-                if result.returncode != 0:
-                     logger.error(f"Patch failed with -p0 as well: {result.stderr or result.stdout}")
-                     raise RuntimeError(f"Failed to apply patch: {result.stderr or result.stdout}")
+                logger.error(f"Patch failed with -p1: {result.stderr or result.stdout}")
+                raise RuntimeError(f"Failed to apply patch: {result.stderr or result.stdout}")
 
             logger.info("Patch applied successfully.")
 


### PR DESCRIPTION
This change addresses the error "not found: /workspace/pytest.ini" during automated verification. It ensures the configuration file is correctly injected into the DockerSandbox and prevents it from being incorrectly identified as a test file to be executed by pytest. Additionally, it removes an incorrect fallback logic in the patching utility to maintain consistency with the project's standards.

Fixes #163

---
*PR created automatically by Jules for task [10206312091884424027](https://jules.google.com/task/10206312091884424027) started by @jonaschen*