### PR TITLE
Initialize Vector Store Infrastructure for Hardware Advisor

### DIFF
--- a/product/bsp_agent/agents/hardware_advisor.py
+++ b/product/bsp_agent/agents/hardware_advisor.py
@@ -1,0 +1,19 @@
+from product.bsp_agent.core.vector_store import VectorStoreManager
+
+class HardwareAdvisorAgent:
+    def __init__(self, vector_store_manager: VectorStoreManager):
+        self.vsm = vector_store_manager
+
+    def get_spec(self, component_name: str) -> str:
+        """Retrieves and formats component specifications from the vector store."""
+        query = f"Specifications for {component_name}"
+        docs = self.vsm.query(query, k=2)
+
+        if not docs:
+            return f"No specifications found for {component_name}."
+
+        specs = []
+        for doc in docs:
+            specs.append(f"Source: {doc.metadata.get('source', 'Unknown')}\nContent: {doc.page_content}")
+
+        return "\n---\n".join(specs)

--- a/product/bsp_agent/core/ingestion.py
+++ b/product/bsp_agent/core/ingestion.py
@@ -1,0 +1,46 @@
+import asyncio
+import logging
+import os
+from typing import List
+from langchain_community.document_loaders import PyPDFLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from product.bsp_agent.core.vector_store import VectorStoreManager
+
+logger = logging.getLogger(__name__)
+
+class DatasheetIngestor:
+    def __init__(self, vector_store_manager: VectorStoreManager):
+        self.vsm = vector_store_manager
+        self.splitter = RecursiveCharacterTextSplitter(
+            chunk_size=1000,
+            chunk_overlap=200
+        )
+
+    async def ingest_pdf(self, file_path: str):
+        """Ingests a PDF file into the vector store asynchronously."""
+        if not os.path.exists(file_path):
+            logger.error(f"File not found: {file_path}")
+            raise FileNotFoundError(f"Datasheet PDF not found at {file_path}")
+
+        try:
+            # Use asyncio.to_thread for non-blocking PDF loading and splitting
+            docs = await asyncio.to_thread(self._load_and_split, file_path)
+
+            if not docs:
+                logger.warning(f"No content extracted from {file_path}")
+                return 0
+
+            texts = [doc.page_content for doc in docs]
+            metadatas = [doc.metadata for doc in docs]
+
+            # Add to vector store
+            await asyncio.to_thread(self.vsm.add_texts, texts, metadatas)
+            logger.info(f"Successfully ingested {len(docs)} chunks from {file_path}")
+            return len(docs)
+        except Exception as e:
+            logger.exception(f"Failed to ingest PDF {file_path}: {e}")
+            raise RuntimeError(f"Failed to process datasheet {file_path}: {e}") from e
+
+    def _load_and_split(self, file_path: str):
+        loader = PyPDFLoader(file_path)
+        return loader.load_and_split(text_splitter=self.splitter)

--- a/product/bsp_agent/core/vector_store.py
+++ b/product/bsp_agent/core/vector_store.py
@@ -1,0 +1,34 @@
+from langchain_chroma import Chroma
+from langchain_google_vertexai import VertexAIEmbeddings
+from studio.config import get_settings
+from typing import List, Optional
+
+class VectorStoreManager:
+    def __init__(self, persist_directory: Optional[str] = None):
+        settings = get_settings()
+        self.persist_directory = persist_directory or settings.vector_store_path
+
+        # Initialize embeddings with the specific model requested
+        self.embeddings = VertexAIEmbeddings(
+            model_name="textembedding-gecko@003",
+            project=settings.google_cloud_project
+        )
+
+        # Initialize Chroma vector store
+        self.vector_store = Chroma(
+            persist_directory=self.persist_directory,
+            embedding_function=self.embeddings,
+            collection_name="bsp_datasheets"
+        )
+
+    def add_texts(self, texts: List[str], metadatas: Optional[List[dict]] = None):
+        """Adds texts to the vector store."""
+        return self.vector_store.add_texts(texts=texts, metadatas=metadatas)
+
+    def query(self, query: str, k: int = 4):
+        """Performs a similarity search."""
+        return self.vector_store.similarity_search(query, k=k)
+
+    def get_retriever(self):
+        """Returns the retriever interface of the vector store."""
+        return self.vector_store.as_retriever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ langchain-google-vertexai
 docker
 networkx
 pydantic-settings
+langchain-chroma
+chromadb
+langchain-community
+langchain-text-splitters
+pypdf

--- a/studio/config.py
+++ b/studio/config.py
@@ -14,6 +14,8 @@ class Settings(BaseSettings):
     github_repository: str = Field(default="google/jules-studio")
     jules_username: str = Field(default="google-jules")
     google_cloud_project: str = Field(default="mock-project")
+    vector_store_path: str = Field(default="data/vector_store")
+    context_window: int = Field(default=1000000)
 
     # Model Stratification Strategy
     thinking_model: str = "gemini-2.5-pro"

--- a/tests/product_tests/test_hardware_advisor.py
+++ b/tests/product_tests/test_hardware_advisor.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import MagicMock
+from product.bsp_agent.agents.hardware_advisor import HardwareAdvisorAgent
+
+def test_get_spec():
+    # Arrange
+    mock_vsm = MagicMock()
+    mock_doc = MagicMock()
+    mock_doc.page_content = "Voltage: 1.8V"
+    mock_doc.metadata = {"source": "pmic_spec.pdf"}
+    mock_vsm.query.return_value = [mock_doc]
+
+    agent = HardwareAdvisorAgent(vector_store_manager=mock_vsm)
+
+    # Act
+    spec = agent.get_spec("PMIC")
+
+    # Assert
+    assert "Voltage: 1.8V" in spec
+    assert "pmic_spec.pdf" in spec
+    mock_vsm.query.assert_called_with("Specifications for PMIC", k=2)
+
+def test_get_spec_no_results():
+    # Arrange
+    mock_vsm = MagicMock()
+    mock_vsm.query.return_value = []
+    agent = HardwareAdvisorAgent(vector_store_manager=mock_vsm)
+
+    # Act
+    spec = agent.get_spec("UnknownComponent")
+
+    # Assert
+    assert "No specifications found" in spec

--- a/tests/product_tests/test_ingestion.py
+++ b/tests/product_tests/test_ingestion.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from product.bsp_agent.core.ingestion import DatasheetIngestor
+
+@pytest.mark.asyncio
+async def test_ingest_pdf():
+    # Arrange
+    mock_vsm = MagicMock()
+    ingestor = DatasheetIngestor(vector_store_manager=mock_vsm)
+
+    mock_doc = MagicMock()
+    mock_doc.page_content = "Sample datasheet content"
+    mock_doc.metadata = {"source": "test.pdf"}
+
+    with patch("product.bsp_agent.core.ingestion.PyPDFLoader") as mock_loader_cls, \
+         patch("product.bsp_agent.core.ingestion.os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        mock_loader = mock_loader_cls.return_value
+        mock_loader.load_and_split.return_value = [mock_doc]
+
+        # Act
+        num_chunks = await ingestor.ingest_pdf("test.pdf")
+
+        # Assert
+        assert num_chunks == 1
+        mock_vsm.add_texts.assert_called_once()
+        args, kwargs = mock_vsm.add_texts.call_args
+        assert args[0] == ["Sample datasheet content"]
+        assert args[1] == [{"source": "test.pdf"}]

--- a/tests/product_tests/test_vector_store.py
+++ b/tests/product_tests/test_vector_store.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from product.bsp_agent.core.vector_store import VectorStoreManager
+
+@pytest.fixture
+def mock_embeddings():
+    with patch("product.bsp_agent.core.vector_store.VertexAIEmbeddings") as mock:
+        mock_instance = MagicMock()
+        mock_instance.embed_query.return_value = [0.1] * 768
+        mock_instance.embed_documents.return_value = [[0.1] * 768]
+        mock.return_value = mock_instance
+        yield mock_instance
+
+def test_vector_store_initialization(mock_embeddings, tmp_path):
+    # Arrange
+    persist_dir = str(tmp_path / "chroma_db")
+
+    # Act
+    vsm = VectorStoreManager(persist_directory=persist_dir)
+
+    # Assert
+    assert vsm.vector_store is not None
+    assert vsm.persist_directory == persist_dir
+
+def test_vector_store_add_and_query(mock_embeddings, tmp_path):
+    # Arrange
+    persist_dir = str(tmp_path / "chroma_db")
+    vsm = VectorStoreManager(persist_directory=persist_dir)
+    content = "The PMIC voltage for the SoC is 1.8V."
+    metadata = {"source": "datasheet_abc.pdf"}
+
+    # Act
+    vsm.add_texts(texts=[content], metadatas=[metadata])
+    results = vsm.query("What is the PMIC voltage?", k=1)
+
+    # Assert
+    assert len(results) > 0
+    assert content in results[0].page_content
+    assert results[0].metadata["source"] == "datasheet_abc.pdf"


### PR DESCRIPTION
This submission initializes the Vector Store infrastructure required for the Hardware Advisor agent as specified in SESSION-01. It implements a ChromaDB-backed vector store, a PDF datasheet ingestor with async support and error handling, and a Hardware Advisor agent capable of retrieving component specifications. The solution follows TDD principles and includes detailed unit tests for all new components.

Fixes #171

---
*PR created automatically by Jules for task [11509981285621207194](https://jules.google.com/task/11509981285621207194) started by @jonaschen*