### PR TITLE
Normalize /workspace/ paths in diffs and verification

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -369,8 +369,15 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
     diff_content = ""
     if jules_data.generated_artifacts:
         diff_content = jules_data.generated_artifacts[0].diff_content
+        # extract_affected_files already performs some normalization
         affected_files = extract_affected_files(diff_content)
-        all_target_files.update(affected_files)
+        for f in affected_files:
+            # Ensure absolute paths or workspace prefixes are stripped
+            # to prevent host-side file-not-found errors.
+            clean_f = f.replace("/workspace/", "").replace("workspace/", "")
+            if clean_f.startswith("/"):
+                clean_f = clean_f[1:]
+            all_target_files.add(clean_f)
 
     # 3. Ensure core testing infrastructure is included
     # This prevents sandbox crashes when Jules doesn't touch tests


### PR DESCRIPTION
The issue was caused by the AI agent (Jules) producing diffs with absolute paths (starting with `/workspace/`) which the host-side verification node failed to map to local files. I implemented a robust normalization layer in `extract_affected_files`, `apply_virtual_patch`, and `node_qa_verifier` to strip these prefixes and ensure consistent file resolution. I also standardized diff headers in the patching utility to use standard `a/` and `b/` prefixes to ensure `patch -p1` always works as expected.

Fixes #177

---
*PR created automatically by Jules for task [5877077401228899927](https://jules.google.com/task/5877077401228899927) started by @jonaschen*