### PR TITLE
Install dependencies from requirements.txt in QA sandbox

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -432,6 +432,10 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
              raise RuntimeError("Failed to setup workspace")
 
         # 3. Install Deps
+        if "requirements.txt" in patched_files:
+            # Prefer requirements.txt for full project dependencies if available
+            sandbox.run_command("pip install -r requirements.txt")
+
         sandbox.install_dependencies(["pytest", "mock"]) # Basic deps
 
         # 4. Run Tests

--- a/tests/test_qa_verifier_infra.py
+++ b/tests/test_qa_verifier_infra.py
@@ -72,3 +72,54 @@ async def test_node_qa_verifier_ensures_infra_files():
         # EXPECTATION: These should be included even if not explicitly in context or patch
         assert "pytest.ini" in setup_call_args, "pytest.ini was NOT included in sandbox"
         assert "tests/test_logic.py" in setup_call_args, "tests/test_logic.py was NOT included in sandbox"
+
+@pytest.mark.asyncio
+async def test_node_qa_verifier_installs_requirements():
+    # 1. Setup State: requirements.txt is present
+    jules_data = JulesMetadata(
+        status="VERIFYING",
+        active_context_slice=ContextSlice(files=["requirements.txt"]),
+        generated_artifacts=[
+            CodeChangeArtifact(
+                diff_content="diff --git a/requirements.txt b/requirements.txt\n--- a/requirements.txt\n+++ b/requirements.txt\n@@ -1,1 +1,2 @@\n pydantic\n+new-dep",
+                change_type="MODIFY"
+            )
+        ]
+    )
+    state: AgentState = {
+        "messages": [],
+        "jules_metadata": jules_data,
+        "system_constitution": "",
+        "next_agent": None
+    }
+
+    # 2. Mock Dependencies
+    with patch("studio.subgraphs.engineer.DockerSandbox") as MockSandbox, \
+         patch("studio.subgraphs.engineer.apply_virtual_patch") as mock_apply, \
+         patch("studio.subgraphs.engineer.extract_affected_files") as mock_extract, \
+         patch("os.path.exists") as mock_exists, \
+         patch("builtins.open") as mock_open:
+
+        mock_extract.return_value = ["requirements.txt"]
+
+        # mock_apply returns patched files including requirements.txt
+        mock_apply.return_value = {"requirements.txt": "pydantic\nnew-dep"}
+
+        mock_exists.return_value = True # Simulate all files exist
+
+        # Mock open
+        mock_file = MagicMock()
+        mock_file.__enter__.return_value.read.return_value = "pydantic"
+        mock_open.return_value = mock_file
+
+        mock_sandbox_inst = MagicMock()
+        MockSandbox.return_value = mock_sandbox_inst
+        mock_sandbox_inst.setup_workspace.return_value = True
+        mock_sandbox_inst.run_pytest.return_value = MagicMock(passed=True, error_log=None)
+        mock_sandbox_inst.run_command.return_value = MagicMock(exit_code=0)
+
+        # 3. Execute the node
+        await node_qa_verifier(state)
+
+        # 4. Verify pip install -r requirements.txt was called
+        mock_sandbox_inst.run_command.assert_any_call("pip install -r requirements.txt")


### PR DESCRIPTION
Enhanced the QA verification node to dynamically install project dependencies from `requirements.txt` when present in the sandbox. This fixes the `ModuleNotFoundError` for `pydantic` reported during automated test collection.

Fixes #189

---
*PR created automatically by Jules for task [3265566007150503048](https://jules.google.com/task/3265566007150503048) started by @jonaschen*