### PR TITLE
Update post_feedback to detect PR and tag bot

### DIFF
--- a/tests/test_jules_client_feedback.py
+++ b/tests/test_jules_client_feedback.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from studio.utils.jules_client import JulesGitHubClient
+from pydantic import SecretStr
+
+@pytest.fixture
+def mock_github():
+    with patch("studio.utils.jules_client.Github") as mock_gh:
+        yield mock_gh
+
+def test_post_feedback_on_pr_when_available(mock_github):
+    client = JulesGitHubClient(github_token=SecretStr("fake_token"), repo_name="owner/repo", jules_username="google-jules")
+
+    mock_repo = MagicMock()
+    client._repo_cache = mock_repo
+
+    mock_issue = MagicMock()
+    mock_repo.get_issue.return_value = mock_issue
+
+    # Mock finding a linked PR
+    mock_pr = MagicMock()
+    with patch.object(JulesGitHubClient, "_find_linked_pr", return_value=mock_pr):
+        success = client.post_feedback("123", "Some feedback")
+
+        assert success is True
+        # Should NOT call create_comment on the issue if PR is found
+        mock_issue.create_comment.assert_not_called()
+        # Should call create_issue_comment on the PR
+        mock_pr.create_issue_comment.assert_called_once()
+        comment_body = mock_pr.create_issue_comment.call_args[0][0]
+        assert "@google-jules" in comment_body
+        assert "Some feedback" in comment_body
+
+def test_post_feedback_on_issue_fallback(mock_github):
+    client = JulesGitHubClient(github_token=SecretStr("fake_token"), repo_name="owner/repo", jules_username="google-jules")
+
+    mock_repo = MagicMock()
+    client._repo_cache = mock_repo
+
+    mock_issue = MagicMock()
+    mock_repo.get_issue.return_value = mock_issue
+
+    # Mock NO linked PR
+    with patch.object(JulesGitHubClient, "_find_linked_pr", return_value=None):
+        success = client.post_feedback("123", "General guidance")
+
+        assert success is True
+        # Should call create_comment on the issue
+        mock_issue.create_comment.assert_called_once()
+        comment_body = mock_issue.create_comment.call_args[0][0]
+        assert "@google-jules" in comment_body
+        assert "General guidance" in comment_body


### PR DESCRIPTION
The `post_feedback` method in `jules_client.py` was updated to prioritize posting feedback to a linked Pull Request if one is available for the given issue. This ensures that code review feedback is visible in the proper context. Additionally, the bot is now explicitly tagged in these comments to ensure visibility.

Key changes:
1. `post_feedback` now calls `_find_linked_pr(issue)` to check for an associated PR.
2. If a PR exists, it uses `pr.create_issue_comment()` to post the feedback.
3. The comment body now starts with `@{self.jules_username}\n` followed by the feedback prefix.
4. Comprehensive tests were added to verify PR detection, fallback to Issue, and correct bot tagging.

Fixes #199

---
*PR created automatically by Jules for task [1713349334539330311](https://jules.google.com/task/1713349334539330311) started by @jonaschen*