### PR TITLE
🧪 Add missing FileNotFoundError test for ArchitectAgent

### DIFF
--- a/tests/test_architect_agent.py
+++ b/tests/test_architect_agent.py
@@ -18,6 +18,14 @@ class TestArchitectAgent(unittest.TestCase):
         self.assertEqual(agent.constitution_content, "CONSTITUTION_CONTENT")
         self.assertIsNotNone(agent.constitution_hash)
 
+    @patch("studio.agents.architect.ChatVertexAI")
+    @patch("builtins.open")
+    def test_load_constitution_file_not_found(self, mock_file, mock_llm):
+        mock_file.side_effect = FileNotFoundError
+        agent = ArchitectAgent()
+        self.assertEqual(agent.constitution_content, "CRITICAL: ENFORCE SOLID. NO AGENTS.MD FOUND.")
+        self.assertEqual(agent.constitution_hash, "EMERGENCY_MODE")
+
     @patch("studio.agents.architect.ArchitectAgent")
     def test_run_architect_gate(self, MockArchitectAgent):
         # Setup mock agent instance


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `ArchitectAgent._load_constitution` method when the `AGENTS.md` file is missing.
📊 **Coverage:** The new test case `test_load_constitution_file_not_found` ensures that the agent correctly handles `FileNotFoundError` by entering 'EMERGENCY_MODE' and setting a critical constitution message.
✨ **Result:** The improvement in test coverage ensures the robustness of the `ArchitectAgent` initialization logic under error conditions.

---
*PR created automatically by Jules for task [7336780328378723250](https://jules.google.com/task/7336780328378723250) started by @jonaschen*