### PR TITLE
🧪 Add tests for ContextSlice.footprint

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,29 @@
 import pytest
-from studio.memory import TestResult
+from studio.memory import TestResult, ContextSlice
+
+def test_context_slice_footprint_determinism():
+    """Test that identical ContextSlice objects produce the same footprint."""
+    c1 = ContextSlice(files=["a.py", "b.py"], issues=["1", "2"])
+    c2 = ContextSlice(files=["a.py", "b.py"], issues=["1", "2"])
+    assert c1.footprint() == c2.footprint()
+
+def test_context_slice_footprint_sorting():
+    """Test that footprint is order-independent for files and issues."""
+    c1 = ContextSlice(files=["a.py", "b.py"], issues=["1", "2"])
+    c2 = ContextSlice(files=["b.py", "a.py"], issues=["2", "1"])
+    assert c1.footprint() == c2.footprint()
+
+def test_context_slice_footprint_sensitivity():
+    """Test that footprint changes when content changes."""
+    c1 = ContextSlice(files=["a.py"], issues=["1"])
+    c2 = ContextSlice(files=["a.py", "b.py"], issues=["1"])
+    assert c1.footprint() != c2.footprint()
+
+def test_context_slice_footprint_empty():
+    """Test footprint generation with empty fields."""
+    c1 = ContextSlice(files=[], issues=[])
+    assert isinstance(c1.footprint(), str)
+    assert len(c1.footprint()) > 0
 
 def test_test_result_summary_success():
     """Test that summary generates correct format for PASS status."""


### PR DESCRIPTION
Added unit tests for `ContextSlice.footprint` in `studio/memory.py` to ensure deterministic hashing (within a process) and correct handling of sorted files and issues.
Verified that the tests pass with `python3 -m pytest tests/test_memory.py`.
Verified no regressions with `python3 -m pytest`.

---
*PR created automatically by Jules for task [11148265319978148905](https://jules.google.com/task/11148265319978148905) started by @jonaschen*