### PR TITLE
Clean up dead code in Orchestrator

### DIFF
--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -39,21 +39,6 @@ from studio.agents.scrum_master import run_scrum_retrospective
 from studio.agents.optimizer import OptimizerAgent
 
 # --- MOCK SUBGRAPHS (Placeholders for compilation) ---
-def engineer_subgraph_node(state: ContextSlice) -> Dict:
-    """Mock execution of the Engineer Subgraph"""
-    # Returns a dict matching AgentStepOutput schema
-    return {
-        "content": "Patch applied.",
-        "thought_process": "Analyzed dependencies and applied fix.",
-        "cognitive_health": {
-            "entropy_score": 0.5,
-            "threshold": 7.0,
-            "sample_size": 5,
-            "is_tunneling": False,
-            "cluster_distribution": {}
-        }
-    }
-
 def sop_guide_node(state: SOPState) -> Dict:
     """Mock execution of the Interactive SOP Guide"""
     return {"current_step_index": state.current_step_index + 1}


### PR DESCRIPTION
**What:** Removed the `engineer_subgraph_node` function from `studio/orchestrator.py`.
**Why:** This function was identified as dead code. The `engineer_subgraph` node in the orchestration graph uses `_engineer_wrapper` instead. This improves code health and maintainability by removing unused artifacts.
**Verification:**
- Verified that `engineer_subgraph_node` was not used anywhere in the codebase using `grep`.
- Ran `tests/test_orchestrator.py` which passed successfully.
**Result:** The codebase is cleaner and free of this specific dead code.

---
*PR created automatically by Jules for task [16662850113326757919](https://jules.google.com/task/16662850113326757919) started by @jonaschen*