### PR TITLE
Refactor noise_patterns to module-level constant

### DIFF
--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -35,6 +35,15 @@ from studio.config import get_settings
 
 logger = logging.getLogger("JulesProxy")
 
+# Ignore common noise patterns from pytest/docs/stdlib
+NOISE_PATTERNS = [
+    "org/en/stable",
+    "unittest/mock.py",
+    "workspace/",
+    "http:",
+    "https:"
+]
+
 def is_valid_local_path(path: str) -> bool:
     """
     Validates if a string that looks like a path is a safe, local project path.
@@ -50,15 +59,8 @@ def is_valid_local_path(path: str) -> bool:
     # 3. Ignore paths escaping current directory
     if ".." in path:
         return False
-    # 4. Ignore common noise patterns from pytest/docs/stdlib
-    noise_patterns = [
-        "org/en/stable",
-        "unittest/mock.py",
-        "workspace/",
-        "http:",
-        "https:"
-    ]
-    for pattern in noise_patterns:
+
+    for pattern in NOISE_PATTERNS:
         if pattern in path:
             return False
 


### PR DESCRIPTION
Moved `noise_patterns` to a module-level constant `NOISE_PATTERNS` in `studio/subgraphs/engineer.py`. This improves code readability and maintainability by separating configuration from the validation logic. Verified with existing unit tests.

---
*PR created automatically by Jules for task [15377133733444449054](https://jules.google.com/task/15377133733444449054) started by @jonaschen*