### PR TITLE
Implement 'Good Enough' Merge Threshold in Architect Agent

### DIFF
--- a/tests/studio_tests/test_architect.py
+++ b/tests/studio_tests/test_architect.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest.mock import MagicMock, patch, mock_open
+import sys
+import os
+
+# Ensure studio can be imported
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from studio.agents.architect import ArchitectAgent, ReviewVerdict, Violation
+
+class TestArchitectGoodEnough(unittest.TestCase):
+
+    def setUp(self):
+        # We need to mock open during __init__
+        with patch("studio.agents.architect.ChatVertexAI"):
+            with patch("builtins.open", mock_open(read_data="CONSTITUTION")):
+                self.agent = ArchitectAgent()
+
+    @patch("langchain_core.runnables.RunnableSequence.invoke")
+    def test_good_enough_threshold_approved_with_tech_debt(self, mock_invoke):
+        """
+        TDD: Code with score 8.5 and only MINOR violations should be APPROVED_WITH_TECH_DEBT.
+        """
+        # Mocking the LLM chain invoke to return a "NEEDS_REFACTOR" verdict with 8.5 score
+        mock_verdict = ReviewVerdict(
+            status="NEEDS_REFACTOR",
+            quality_score=8.5,
+            violations=[
+                Violation(
+                    rule_id="SRP",
+                    severity="MINOR",
+                    description="Slightly long method",
+                    file_path="test.py",
+                    suggested_fix="Break it down"
+                )
+            ]
+        )
+        mock_invoke.return_value = mock_verdict
+
+        verdict = self.agent.review_code("test.py", "print('hello')", "TKT-1")
+
+        self.assertEqual(verdict.status, "APPROVED_WITH_TECH_DEBT")
+        self.assertEqual(verdict.tech_debt_tag, "#TODO: Tech Debt")
+
+    @patch("langchain_core.runnables.RunnableSequence.invoke")
+    def test_below_threshold_remains_needs_refactor(self, mock_invoke):
+        """
+        Code with score 7.5 should remain NEEDS_REFACTOR.
+        """
+        mock_verdict = ReviewVerdict(
+            status="NEEDS_REFACTOR",
+            quality_score=7.5,
+            violations=[
+                Violation(
+                    rule_id="SRP",
+                    severity="MAJOR",
+                    description="Too complex",
+                    file_path="test.py",
+                    suggested_fix="Split it"
+                )
+            ]
+        )
+        mock_invoke.return_value = mock_verdict
+
+        verdict = self.agent.review_code("test.py", "complex code", "TKT-1")
+
+        self.assertEqual(verdict.status, "NEEDS_REFACTOR")
+
+    @patch("langchain_core.runnables.RunnableSequence.invoke")
+    def test_critical_violation_remains_rejected(self, mock_invoke):
+        """
+        Code with score 9.0 but a CRITICAL violation should remain REJECTED.
+        """
+        mock_verdict = ReviewVerdict(
+            status="REJECTED",
+            quality_score=9.0,
+            violations=[
+                Violation(
+                    rule_id="SEC",
+                    severity="CRITICAL",
+                    description="Hardcoded secret",
+                    file_path="test.py",
+                    suggested_fix="Use env var"
+                )
+            ]
+        )
+        mock_invoke.return_value = mock_verdict
+
+        verdict = self.agent.review_code("test.py", "secret='123'", "TKT-1")
+
+        self.assertEqual(verdict.status, "REJECTED")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change implements a 'Good Enough' merge threshold in the Architect Agent to prevent infinite refactoring loops. 

Key changes:
1.  **_apply_good_enough_threshold in ArchitectAgent**: A new method that evaluates the LLM's verdict. If the quality score is 8.0 or higher and there are no CRITICAL violations, the status is upgraded to `APPROVED_WITH_TECH_DEBT` (if not already `APPROVED`).
2.  **Tech Debt Tagging**: Automatically appends `#TODO: Tech Debt` to the `tech_debt_tag` field when the status is `APPROVED_WITH_TECH_DEBT`.
3.  **Gate Status Update**: The `run_architect_gate` function now treats `APPROVED_WITH_TECH_DEBT` as a passing ("GREEN") status.
4.  **TDD Tests**: New test cases in `tests/studio_tests/test_architect.py` verify the threshold logic, ensuring that good code is accepted while poor code or code with critical violations is still rejected.
5.  **Modernization**: Transitioned from `dict()` to `model_dump()` for Pydantic V2 compatibility.

Fixes #245

---
*PR created automatically by Jules for task [2492280745668954250](https://jules.google.com/task/2492280745668954250) started by @jonaschen*