### PR TITLE
Define Datasheet Schema & Metadata (SESSION-01)

### DIFF
--- a/fixtures/datasheets/dram_mt53e.json
+++ b/fixtures/datasheets/dram_mt53e.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "component_type": "DRAM",
+    "part_number": "MT53E",
+    "manufacturer": "Micron",
+    "voltage_range": {"min": 0.6, "max": 1.1, "unit": "V"},
+    "timing_specs": {"speed": "LPDDR5-6400"},
+    "interfaces": ["LPDDR5"]
+  },
+  "content": "Micron LPDDR5 is a high-speed CMOS, dynamic random-access memory configured as 8 channels. It uses a double data rate architecture on the command/address (CA) bus to reduce the number of input pins in the system.",
+  "source_url": "https://www.micron.com/products/dram/lpddr5"
+}

--- a/fixtures/datasheets/ldo_tps7a84.json
+++ b/fixtures/datasheets/ldo_tps7a84.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "component_type": "LDO",
+    "part_number": "TPS7A84",
+    "manufacturer": "TI",
+    "voltage_range": {"min": 0.8, "max": 5.2, "unit": "V"},
+    "timing_specs": {"startup_time": "500us"},
+    "interfaces": ["EN", "PG"]
+  },
+  "content": "The TPS7A84 is a low-noise, high-PSRR, low-dropout regulator capable of sourcing 3 A with only 180 mV of maximum dropout. It is ideal for powering sensitive analog components.",
+  "source_url": "https://www.ti.com/lit/ds/symlink/tps7a84.pdf"
+}

--- a/fixtures/datasheets/pmic_tps6594.json
+++ b/fixtures/datasheets/pmic_tps6594.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "component_type": "PMIC",
+    "part_number": "TPS6594",
+    "manufacturer": "TI",
+    "voltage_range": {"min": 0.6, "max": 3.3, "unit": "V"},
+    "timing_specs": {"i2c_speed": "1MHz"},
+    "interfaces": ["I2C", "GPIO", "SPMI"]
+  },
+  "content": "The TPS6594 is a highly integrated power management IC for automotive and industrial applications. It features five high-efficiency step-down regulators and four LDOs. It supports I2C for communication and control.",
+  "source_url": "https://www.ti.com/lit/ds/symlink/tps6594.pdf"
+}

--- a/fixtures/datasheets/soc_sdm845.json
+++ b/fixtures/datasheets/soc_sdm845.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "component_type": "SoC",
+    "part_number": "SDM845",
+    "manufacturer": "Qualcomm",
+    "voltage_range": {"core_v": 0.8, "io_v": 1.8},
+    "timing_specs": {"cpu_max": "2.8GHz"},
+    "interfaces": ["LPDDR4X", "UFS 2.1", "PCIe Gen 3"]
+  },
+  "content": "Snapdragon 845 is a high-end ARM SoC for smartphones. It integrates 8 Kryo 385 cores, an Adreno 630 GPU, and a Hexagon 685 DSP. It supports dual-channel LPDDR4X-1866 memory.",
+  "source_url": "https://www.qualcomm.com/products/snapdragon-845-mobile-platform"
+}

--- a/fixtures/datasheets/ufs_k3uh7h7.json
+++ b/fixtures/datasheets/ufs_k3uh7h7.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "component_type": "UFS",
+    "part_number": "K3UH7H7",
+    "manufacturer": "Samsung",
+    "voltage_range": {"vcc": 2.95, "vccq": 1.2},
+    "timing_specs": {"read_speed": "2100MB/s"},
+    "interfaces": ["UFS 3.1", "MIPI M-PHY"]
+  },
+  "content": "Samsung UFS 3.1 is a high-performance flash storage device designed for mobile devices. It provides exceptional read/write speeds and low power consumption.",
+  "source_url": "https://semiconductor.samsung.com/storage/mobile-storage/ufs/"
+}

--- a/product/schemas/datasheet.py
+++ b/product/schemas/datasheet.py
@@ -1,0 +1,38 @@
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field
+
+class DatasheetMetadata(BaseModel):
+    """
+    Metadata for a hardware component datasheet.
+    Used for filtering and structured retrieval in the RAG pipeline.
+    """
+    component_type: str = Field(..., description="Type of component (e.g., PMIC, DRAM, SoC)", examples=["PMIC", "DRAM"])
+    part_number: str = Field(..., description="Manufacturer part number", examples=["TPS6594", "MT53E"])
+    manufacturer: str = Field(..., description="Manufacturer name", examples=["TI", "Micron", "Qualcomm"])
+    voltage_range: Optional[Dict[str, Any]] = Field(None, description="Operating voltage range details", examples=[{"min": 0.6, "max": 3.3, "unit": "V"}])
+    timing_specs: Optional[Dict[str, Any]] = Field(None, description="Timing characteristics (e.g., clock speeds)", examples=[{"i2c_speed": "400kHz"}])
+    interfaces: List[str] = Field(default_factory=list, description="Supported interfaces (e.g., I2C, SPI, LPDDR5)", examples=[["I2C", "GPIO"]])
+
+class Datasheet(BaseModel):
+    """
+    The core representation of a datasheet in the repository.
+
+    ### Vector Embedding Strategy:
+    To optimize for RAG, the following fields are concatenated for vectorization:
+    - component_type
+    - part_number
+    - manufacturer
+    - interfaces
+    - content (summary or key sections)
+
+    The metadata is stored in the vector store's 'metadata' field for hard-filtering
+    (e.g., searching ONLY for 'PMIC' components).
+
+    ### Expected Retrieval Query Patterns:
+    1. "What is the voltage range for TPS6594?" -> Filter by part_number='TPS6594'
+    2. "List I2C PMICs for Pixel 8" -> Filter by component_type='PMIC' and search 'I2C'
+    3. "Timing specs for LPDDR5 on SoC SDM845" -> Search 'LPDDR5 SDM845 timing'
+    """
+    metadata: DatasheetMetadata = Field(..., description="Structured metadata for the component")
+    content: str = Field(..., description="Text content of the datasheet or relevant excerpts")
+    source_url: Optional[str] = Field(None, description="Link to the original PDF or source", examples=["https://example.com/datasheet.pdf"])

--- a/tests/product_tests/test_datasheet_schema.py
+++ b/tests/product_tests/test_datasheet_schema.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+try:
+    from product.schemas.datasheet import Datasheet, DatasheetMetadata
+except ImportError:
+    Datasheet = None
+    DatasheetMetadata = None
+
+def test_datasheet_imports():
+    assert Datasheet is not None, "Datasheet model not found in product.schemas.datasheet"
+    assert DatasheetMetadata is not None, "DatasheetMetadata model not found in product.schemas.datasheet"
+
+def test_datasheet_metadata_validation():
+    if DatasheetMetadata is None:
+        pytest.fail("DatasheetMetadata not imported")
+
+    # Test valid metadata
+    valid_data = {
+        "component_type": "PMIC",
+        "part_number": "TPS6594",
+        "voltage_range": {"min": 0.6, "max": 3.3, "unit": "V"},
+        "timing_specs": {"i2c_speed": "400kHz"},
+        "manufacturer": "TI"
+    }
+    metadata = DatasheetMetadata(**valid_data)
+    assert metadata.component_type == "PMIC"
+    assert metadata.part_number == "TPS6594"
+
+def test_datasheet_validation():
+    if Datasheet is None:
+        pytest.fail("Datasheet not imported")
+
+    valid_data = {
+        "metadata": {
+            "component_type": "DRAM",
+            "part_number": "MT53E",
+            "manufacturer": "Micron"
+        },
+        "content": "Full datasheet text content here...",
+        "source_url": "https://example.com/datasheet.pdf"
+    }
+    datasheet = Datasheet(**valid_data)
+    assert datasheet.metadata.component_type == "DRAM"
+    assert datasheet.content == "Full datasheet text content here..."


### PR DESCRIPTION
Defined the data contracts and metadata schema for the datasheet repository, created 5 representative sample fixtures, and documented retrieval patterns and embedding strategies. Verified with TDD-style unit tests.

Fixes #258

---
*PR created automatically by Jules for task [6464223259482423609](https://jules.google.com/task/6464223259482423609) started by @jonaschen*