### PR TITLE
Implement Post-Merge Git Synchronization for the Orchestrator

### DIFF
--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -37,6 +37,7 @@ from studio.memory import JulesMetadata, VerificationGate, EngineeringState
 from studio.agents.product_owner import run_po_cycle
 from studio.agents.scrum_master import run_scrum_retrospective
 from studio.agents.optimizer import OptimizerAgent
+from studio.utils.git_utils import sync_main_branch
 
 # --- MOCK SUBGRAPHS (Placeholders for compilation) ---
 def sop_guide_node(state: SOPState) -> Dict:
@@ -207,7 +208,8 @@ class Orchestrator:
             if updated_tkt:
                 if updated_tkt.status == "COMPLETED":
                     orch.completed_tasks_log.append(updated_tkt)
-                    self.logger.info(f"Task {updated_tkt.id} completed.")
+                    self.logger.info(f"Task {updated_tkt.id} completed. Synchronizing local workspace with main branch.")
+                    await asyncio.to_thread(sync_main_branch)
                 elif updated_tkt.status == "FAILED":
                     orch.failed_tasks_log.append(updated_tkt)
                     self.logger.info(f"Task {updated_tkt.id} failed.")

--- a/studio/utils/git_utils.py
+++ b/studio/utils/git_utils.py
@@ -29,3 +29,24 @@ def checkout_pr_branch(branch_name: str):
     except subprocess.CalledProcessError as e:
         logger.error(f"Git checkout {branch_name} failed: {e}")
         raise
+
+def sync_main_branch():
+    """
+    Synchronizes the local main branch with the remote origin.
+    Executes: git checkout main && git pull origin main
+    """
+    logger.info("Synchronizing local workspace with main branch.")
+
+    # 1. Checkout main
+    try:
+        subprocess.run(["git", "checkout", "main"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git checkout main failed: {e}")
+        raise
+
+    # 2. Pull from origin main
+    try:
+        subprocess.run(["git", "pull", "origin", "main"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git pull origin main failed: {e}")
+        raise

--- a/tests/studio_tests/test_git_sync.py
+++ b/tests/studio_tests/test_git_sync.py
@@ -1,0 +1,88 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+from studio.memory import (
+    StudioState, OrchestrationState, EngineeringState, JulesMetadata, Ticket
+)
+from studio.orchestrator import Orchestrator
+
+@pytest.mark.asyncio
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+@patch("studio.orchestrator.asyncio.to_thread")
+async def test_node_backlog_dispatcher_syncs_git_on_completion(mock_to_thread, mock_gen_model, mock_vertex_judge):
+    # Setup state where a task has just COMPLETED
+    completed_ticket = Ticket(
+        id="TKT-1",
+        title="Test Task",
+        description="A test task",
+        priority="HIGH",
+        source_section_id="1.1",
+        status="OPEN"
+    )
+
+    orch_state = OrchestrationState(
+        session_id="test_session",
+        user_intent="CODING",
+        sprint_backlog=[completed_ticket]
+    )
+
+    eng_state = EngineeringState(
+        current_task="Test Task: A test task",
+        jules_meta=JulesMetadata(status="COMPLETED")
+    )
+
+    state = StudioState(orchestration=orch_state, engineering=eng_state)
+
+    # We need to import the sync_main_branch function to mock it
+    # Even if it doesn't exist yet, we can patch the path where it will be called.
+    with patch("studio.orchestrator.sync_main_branch", create=True) as mock_sync:
+        orchestrator = Orchestrator()
+
+        # We need to mock to_thread to actually call the mocked sync_main_branch if we use to_thread
+        async def side_effect(func, *args, **kwargs):
+            if func == mock_sync:
+                return func(*args, **kwargs)
+            return MagicMock()
+
+        mock_to_thread.side_effect = side_effect
+
+        await orchestrator.node_backlog_dispatcher(state)
+
+        # Verify sync_main_branch was called
+        mock_sync.assert_called_once()
+
+@pytest.mark.asyncio
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+@patch("studio.orchestrator.asyncio.to_thread")
+async def test_node_backlog_dispatcher_does_not_sync_git_on_failure(mock_to_thread, mock_gen_model, mock_vertex_judge):
+    # Setup state where a task has FAILED
+    failed_ticket = Ticket(
+        id="TKT-2",
+        title="Failed Task",
+        description="A task that failed",
+        priority="HIGH",
+        source_section_id="1.1",
+        status="OPEN"
+    )
+
+    orch_state = OrchestrationState(
+        session_id="test_session",
+        user_intent="CODING",
+        sprint_backlog=[failed_ticket]
+    )
+
+    eng_state = EngineeringState(
+        current_task="Failed Task: A task that failed",
+        jules_meta=JulesMetadata(status="FAILED")
+    )
+
+    state = StudioState(orchestration=orch_state, engineering=eng_state)
+
+    with patch("studio.orchestrator.sync_main_branch", create=True) as mock_sync:
+        orchestrator = Orchestrator()
+        await orchestrator.node_backlog_dispatcher(state)
+
+        # Verify sync_main_branch was NOT called
+        mock_sync.assert_not_called()


### PR DESCRIPTION
Implemented an automated synchronization step in the Orchestrator to pull the latest main branch after a task is successfully merged. This was achieved by adding a `sync_main_branch` utility function and integrating it into the `backlog_dispatcher` node of the orchestrator's state machine. The change is verified with new unit tests ensuring the sync only occurs on task completion.

Fixes #261

---
*PR created automatically by Jules for task [8232722661217058902](https://jules.google.com/task/8232722661217058902) started by @jonaschen*