### PR TITLE
Formalize Agent Personas & Input/Output Contracts

### DIFF
--- a/product/schemas/__init__.py
+++ b/product/schemas/__init__.py
@@ -35,7 +35,7 @@ class TriageReport(BaseModel):
 class RCAReport(BaseModel):
     """Root Cause Analysis Report."""
     diagnosis_id: str = Field(..., description="Unique identifier for this diagnosis", examples=["RCA-001", "RCA-BSP-042"])
-    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in the diagnosis", examples=[0.95, 0.80])
+    confidence_score: float = Field(..., ge=0.0, le=1.0, description="Confidence in the diagnosis", examples=[0.95, 0.80])
     root_cause_summary: str = Field(..., description="Brief summary of the root cause", examples=["Null pointer dereference in mdss driver", "I2C bus contention during resume"])
     technical_detail: str = Field(..., description="Deep dive into the technical root cause", examples=["The driver attempted to access a clock pointer before it was initialized...", "A race condition between the I2C master and a slave device caused a timeout."])
     suggested_fix: str = Field(..., description="Recommended code or hardware fix", examples=["Add a NULL check for clk_ptr in mdss_dsi_probe", "Increase I2C timeout value in device tree"])
@@ -44,7 +44,7 @@ class RCAReport(BaseModel):
 class ConsultantResponse(BaseModel):
     """The standardized output for all Consultant agents."""
     diagnosis_id: str = Field(..., description="Unique ID for this diagnosis", examples=["RCA-BSP-001", "DIAG-PATH-001"])
-    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in the diagnosis", examples=[0.85, 0.99])
+    confidence_score: float = Field(..., ge=0.0, le=1.0, description="Confidence in the diagnosis", examples=[0.85, 0.99])
     status: Literal["CRITICAL", "WARNING", "INFO", "CLARIFY_NEEDED"] = Field(..., description="Status of the analysis", examples=["CRITICAL", "INFO"])
     root_cause_summary: str = Field(..., description="Brief summary of the root cause", examples=["I2C bus contention during resume", "Null pointer dereference in kernel"])
     evidence: List[str] = Field(..., description="Evidence supporting the diagnosis (e.g., log lines)", examples=["[ 1450.02] i2c_transfer_timeout", "pc : [<ffffffc000080000>]"])
@@ -61,7 +61,7 @@ class SupervisorInput(BaseModel):
 class PathologistOutput(BaseModel):
     """Output contract for the Kernel Pathologist Agent."""
     suspected_module: str = Field(..., description="The kernel module or subsystem suspected of failure", examples=["drivers/usb/dwc3/", "kernel/irq/"])
-    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in the pathologist's diagnosis", examples=[0.95, 0.70])
+    confidence_score: float = Field(..., ge=0.0, le=1.0, description="Confidence in the pathologist's diagnosis", examples=[0.95, 0.70])
     evidence: List[str] = Field(..., description="Key log lines or patterns supporting the suspicion", examples=["[ 123.456] Unable to handle kernel NULL pointer dereference", "pc : [<ffffffc000080000>]"])
     sop_steps: List[SOPStep] = Field(..., description="Recommended SOP steps for verification or fix", examples=[{"step_id": 1, "action_type": "CODE_PATCH", "instruction": "Add NULL check", "expected_value": "No panic", "file_path": "drivers/usb/dwc3/gadget.c"}])
 
@@ -76,7 +76,7 @@ class HardwareAdvisorOutput(BaseModel):
     """Output contract for the Hardware Advisor Agent."""
     voltage_specs: Optional[str] = Field(None, description="Voltage requirements from datasheet", examples=["1.8V +/- 5%", "0.8V VDD_CORE"])
     timing_specs: Optional[str] = Field(None, description="Timing requirements from datasheet", examples=["tVAC min 100ns", "tCK 1.25ns"])
-    soa_info: Optional[str] = Field(None, description="Safe Operating Area details", examples=["Max junction temp 125C", "Max current 2A"])
-    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in the specs retrieved", examples=[0.99, 0.85])
+    soa: Optional[str] = Field(None, description="Safe Operating Area details", examples=["Max junction temp 125C", "Max current 2A"])
+    confidence_score: float = Field(..., ge=0.0, le=1.0, description="Confidence in the specs retrieved", examples=[0.99, 0.85])
     evidence: List[str] = Field(..., description="Supporting excerpts from the datasheet", examples=["Table 5.1: VDD range 1.7V to 1.9V"])
     sop_steps: List[SOPStep] = Field(..., description="Measurement instructions for the human", examples=[{"step_id": 1, "action_type": "MEASUREMENT", "instruction": "Measure TP34", "expected_value": "1.8V", "file_path": "N/A"}])

--- a/tests/product_tests/test_agent_contracts.py
+++ b/tests/product_tests/test_agent_contracts.py
@@ -56,7 +56,7 @@ def test_triage_report_serialization():
 def test_rca_report_serialization():
     data = {
         "diagnosis_id": "RCA-001",
-        "confidence": 0.9,
+        "confidence_score": 0.9,
         "root_cause_summary": "Summary",
         "technical_detail": "Detail",
         "suggested_fix": "Fix",
@@ -77,7 +77,7 @@ def test_sop_step_serialization():
 def test_consultant_response_serialization():
     data = {
         "diagnosis_id": "DIAG-001",
-        "confidence": 0.85,
+        "confidence_score": 0.85,
         "status": "WARNING",
         "root_cause_summary": "Summary",
         "evidence": ["Evidence"],
@@ -110,7 +110,7 @@ def test_supervisor_input_serialization():
 def test_pathologist_output_serialization():
     pathologist_data = {
         "suspected_module": "drivers/usb/dwc3/",
-        "confidence": 0.95,
+        "confidence_score": 0.95,
         "evidence": ["Attempted to access offset 0x20 of NULL pointer"],
         "sop_steps": [
             {
@@ -152,8 +152,8 @@ def test_hardware_advisor_output_serialization():
     hardware_output_data = {
         "voltage_specs": "1.8V",
         "timing_specs": "400kHz",
-        "soa_info": "Max 85C",
-        "confidence": 0.8,
+        "soa": "Max 85C",
+        "confidence_score": 0.8,
         "evidence": ["Datasheet Table 1"],
         "sop_steps": [
             {
@@ -171,8 +171,8 @@ def test_hardware_advisor_output_confidence_validation():
     invalid_hw_data = {
         "voltage_specs": "1.8V",
         "timing_specs": "400kHz",
-        "soa_info": "Max 85C",
-        "confidence": 1.5, # Out of bounds [0.0, 1.0]
+        "soa": "Max 85C",
+        "confidence_score": 1.5, # Out of bounds [0.0, 1.0]
         "evidence": [],
         "sop_steps": []
     }
@@ -182,7 +182,7 @@ def test_hardware_advisor_output_confidence_validation():
 def test_pathologist_output_confidence_validation():
     invalid_path_data = {
         "suspected_module": "module",
-        "confidence": -0.1, # Out of bounds [0.0, 1.0]
+        "confidence_score": -0.1, # Out of bounds [0.0, 1.0]
         "evidence": [],
         "sop_steps": []
     }


### PR DESCRIPTION
This change formalizes the interfaces between Supervisor, Pathologist, and Hardware Advisor agents by defining structured Pydantic models in product/schemas/__init__.py. It also aligns confidence and SOA field naming across all models for consistency.

Fixes #264

---
*PR created automatically by Jules for task [14206868473986978470](https://jules.google.com/task/14206868473986978470) started by @jonaschen*