### PR TITLE
[Bug] Update studio_state.seed.json to Match Pydantic StudioState Schema

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ async def run_studio():
     config = {"configurable": {"thread_id": "studio-session-v1"}, "recursion_limit": 100}
 
     async with AsyncSqliteSaver.from_conn_string(CHECKPOINT_DB) as checkpointer:
-        orchestrator = Orchestrator(checkpointer=checkpointer)
+        orchestrator = Orchestrator(checkpointer=checkpointer, manager=manager)
 
         try:
             logging.info("Starting Orchestration Loop...")

--- a/studio/studio_state.seed.json
+++ b/studio/studio_state.seed.json
@@ -1,120 +1,31 @@
 {
-  "studio_meta": {
-    "system_version": "5.1.0",
-    "constitution_hash": "sha256:a1b2c3d4...",
-    "current_phase": "MVP_SCAFFOLDING",
-    "simulation_mode": false,
-    "last_updated": "2026-02-08T10:00:00Z"
-  },
-
-  "orchestration_state": {
-    "sprint_board": {
-      "sprint_id": "SPRINT-01",
-      "sprint_goal": "Implement Supervisor Agent Log Chunking Strategy (Fix #3)",
-      "start_date": "2026-02-08",
-      "end_date": "2026-02-22",
-      "tickets": {
-        "TKT-101": {
-          "id": "TKT-101",
-          "title": "Setup Vertex AI Client",
-          "status": "DONE",
-          "assigned_to": "Engineer",
-          "priority": "HIGH"
+    "system_version": "5.2.0",
+    "circuit_breaker_triggered": false,
+    "escalation_triggered": false,
+    "orchestration": {
+        "session_id": "SESSION-00",
+        "user_intent": "BOOTSTRAP",
+        "full_logs": "",
+        "triage_status": null,
+        "guidance_sop": null,
+        "current_context_slice": null,
+        "task_queue": [],
+        "task_max_retries": 5,
+        "current_sprint_id": null,
+        "sprint_goal": null,
+        "sprint_backlog": [],
+        "completed_tasks_log": [],
+        "failed_tasks_log": []
+    },
+    "engineering": {
+        "current_task": null,
+        "verification_gate": {
+            "status": "PENDING",
+            "failure_counter": 0,
+            "blocking_reason": null
         },
-        "TKT-102": {
-          "id": "TKT-102",
-          "title": "Implement Log Chunking (>50MB)",
-          "status": "IN_PROGRESS",
-          "assigned_to": "Engineer",
-          "priority": "CRITICAL",
-          "acceptance_criteria": [
-            "Must verify file size > 50MB",
-            "Must slice last 5000 lines or +/- 10s from failure"
-          ]
-        }
-      },
-      "blockers": []
+        "proposed_patch": null,
+        "jules_meta": null
     },
-    "inquiry_session": {
-      "_privacy_level": "CONFIDENTIAL_USER_DATA",
-      "session_id": "SESS-8829",
-      "user_intent": "Debug Kernel Panic on Resume",
-      "interaction_history": [
-        {
-          "role": "user",
-          "content": "My device hangs during suspend. Logs attached.",
-          "timestamp": "2026-02-08T09:30:00Z"
-        }
-      ],
-      "active_agent": "Engineer"
-    }
-  },
-
-  "engineering_state": {
-    "workspace_snapshot": {
-      "current_file": "product/agents/supervisor.py",
-      "git_branch": "feature/log-chunking",
-      "diff_stat": "+45 lines, -2 lines"
-    },
-    "code_artifacts": {
-      "proposed_patch": "def chunk_log(file_path): ...",
-      "justification_refs": [
-        "PRODUCT_BLUEPRINT.md#Section2.Supervisor",
-        "TKT-102#AcceptanceCriteria"
-      ],
-      "lint_score": 9.8
-    },
-    "verification_gate": {
-      "status": "RED",
-      "latest_test_run": {
-        "test_id": "test_chunking_large_file",
-        "outcome": "FAIL",
-        "error_message": "IndexError: list index out of range",
-        "duration_ms": 142
-      },
-      "failure_counter": 1
-    }
-  },
-
-  "optimization_state": {
-    "target_prompt": "product/prompts/pathologist.yaml",
-    "optimization_trajectory": [
-      {
-        "iteration": 1,
-        "prompt_hash": "abc1234",
-        "score": 0.72,
-        "feedback": "Agent failed to identify the file path correctly."
-      }
-    ],
-    "hard_negatives": [
-      {
-        "input_id": "case_005_obfuscated_path",
-        "expected": "drivers/gpu/drm/msm/mdss.c",
-        "actual": "drivers/gpu/drm/msm/mdss_dsi.c"
-      }
-    ]
-  },
-
-  "episodic_memory": {
-    "architectural_decision_records": [
-      {
-        "id": "ADR-001",
-        "title": "Adopt LangGraph for State Management",
-        "date": "2026-02-08",
-        "status": "ACCEPTED",
-        "consequences": [
-          "Requires strict schema definition (Pydantic)",
-          "Enables time-travel debugging"
-        ]
-      }
-    ],
-    "retrospective_insights": [
-      {
-        "sprint_id": "SPRINT-00",
-        "insight_type": "PROCESS_IMPROVEMENT",
-        "observation": "Engineer hallucinates file paths without grep.",
-        "action_item": "Enforce use of 'verify_file_exists' tool in Pathologist prompt."
-      }
-    ]
-  }
+    "privacy_mode": true
 }

--- a/studio_state.seed.json
+++ b/studio_state.seed.json
@@ -3,7 +3,7 @@
     "circuit_breaker_triggered": false,
     "escalation_triggered": false,
     "orchestration": {
-        "session_id": "RECOVERY-TEST",
+        "session_id": "SESSION-00",
         "user_intent": "BOOTSTRAP",
         "full_logs": "",
         "triage_status": null,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -11,11 +11,12 @@ from studio.orchestrator import Orchestrator
 # Set mock project to avoid Google Auth errors
 os.environ["GOOGLE_CLOUD_PROJECT"] = "mock-project"
 
+@patch("studio.orchestrator.sync_main_branch")
 @patch("studio.orchestrator.VertexFlashJudge")
 @patch("studio.orchestrator.GenerativeModel")
 @patch("studio.orchestrator.run_po_cycle")
 @patch("studio.orchestrator.run_scrum_retrospective")
-def test_orchestrator_coding_flow(mock_run_retrospective, mock_run_po, mock_gen_model, mock_vertex_judge):
+def test_orchestrator_coding_flow(mock_run_retrospective, mock_run_po, mock_gen_model, mock_vertex_judge, mock_sync):
     # Setup state for CODING intent
     orch_state = OrchestrationState(
         session_id="test_1",

--- a/tests/test_persistence_transitions.py
+++ b/tests/test_persistence_transitions.py
@@ -1,0 +1,125 @@
+import os
+import json
+import pytest
+import asyncio
+import tempfile
+from unittest.mock import MagicMock, AsyncMock, patch
+from studio.memory import (
+    StudioState, OrchestrationState, EngineeringState, Ticket,
+    JulesMetadata, SemanticHealthMetric
+)
+from studio.orchestrator import Orchestrator
+from studio.manager import StudioManager
+
+# Set mock project to avoid Google Auth errors
+os.environ["GOOGLE_CLOUD_PROJECT"] = "mock-project"
+
+@patch("studio.orchestrator.sync_main_branch")
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+@pytest.mark.asyncio
+async def test_persistence_on_task_completion(mock_gen_model, mock_vertex_judge, mock_sync):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize Manager and State
+        manager = StudioManager(root_dir=temp_dir)
+        ticket = Ticket(id="TKT-1", title="Task 1", description="Desc", priority="HIGH", source_section_id="1.1", status="IN_PROGRESS")
+        manager.state.orchestration.sprint_backlog = [ticket]
+        manager.state.engineering.current_task = "Task 1: Desc"
+        manager.state.engineering.jules_meta = JulesMetadata(status="COMPLETED")
+
+        # Setup Orchestrator with Manager
+        mock_engineer_app = MagicMock()
+        orchestrator = Orchestrator(engineer_app=mock_engineer_app, manager=manager)
+
+        # Invoke node_backlog_dispatcher
+        await orchestrator.node_backlog_dispatcher(manager.state)
+
+        # Verify studio_state.json on disk matches in-memory state
+        state_path = os.path.join(temp_dir, "studio_state.json")
+        assert os.path.exists(state_path)
+        with open(state_path, "r") as f:
+            saved_data = json.load(f)
+            # Ticket should be removed from backlog and added to completed_tasks_log
+            assert len(saved_data["orchestration"]["sprint_backlog"]) == 0
+            assert len(saved_data["orchestration"]["completed_tasks_log"]) == 1
+            assert saved_data["orchestration"]["completed_tasks_log"][0]["id"] == "TKT-1"
+
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+@pytest.mark.asyncio
+async def test_persistence_on_circuit_breaker(mock_gen_model, mock_vertex_judge):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Initialize Manager and State
+        manager = StudioManager(root_dir=temp_dir)
+        manager.state.orchestration.user_intent = "CODING"
+        manager.state.engineering.current_task = "Fix bug"
+
+        # Setup Orchestrator with Manager and Mock Entropy
+        mock_engineer_app = MagicMock()
+        mock_engineer_app.ainvoke = AsyncMock(return_value={
+            "jules_metadata": JulesMetadata(status="WORKING", generated_artifacts=[])
+        })
+
+        orchestrator = Orchestrator(engineer_app=mock_engineer_app, manager=manager)
+
+        # Mock high entropy to trigger circuit breaker
+        mock_metric = SemanticHealthMetric(
+            entropy_score=9.5,
+            threshold=7.0,
+            sample_size=5,
+            is_tunneling=True,
+            cluster_distribution={}
+        )
+        orchestrator.calculator.measure_uncertainty = AsyncMock(return_value=mock_metric)
+
+        # Invoke _engineer_wrapper
+        await orchestrator._engineer_wrapper(manager.state)
+
+        # Verify studio_state.json on disk
+        state_path = os.path.join(temp_dir, "studio_state.json")
+        assert os.path.exists(state_path)
+        with open(state_path, "r") as f:
+            saved_data = json.load(f)
+            assert saved_data["circuit_breaker_triggered"] is True
+            assert saved_data["engineering"]["jules_meta"]["status"] == "WORKING"
+
+@patch("studio.orchestrator.sync_main_branch")
+@patch("studio.orchestrator.VertexFlashJudge")
+@patch("studio.orchestrator.GenerativeModel")
+@pytest.mark.asyncio
+async def test_no_redispatch_after_recovery(mock_gen_model, mock_vertex_judge, mock_sync):
+    """Verifies that a completed task is not re-dispatched if the system restarts."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # 1. First Run: Task completes
+        manager = StudioManager(root_dir=temp_dir)
+        ticket = Ticket(id="TKT-1", title="Task 1", description="Desc", priority="HIGH", source_section_id="1.1", status="IN_PROGRESS")
+        manager.state.orchestration.sprint_backlog = [ticket]
+        manager.state.engineering.current_task = "Task 1: Desc"
+        manager.state.engineering.jules_meta = JulesMetadata(status="COMPLETED")
+
+        mock_engineer_app = MagicMock()
+        orchestrator = Orchestrator(engineer_app=mock_engineer_app, manager=manager)
+
+        await orchestrator.node_backlog_dispatcher(manager.state)
+
+        # 2. Simulate Crash/Restart: Initialize new Manager and Orchestrator
+        new_manager = StudioManager(root_dir=temp_dir)
+        assert len(new_manager.state.orchestration.completed_tasks_log) == 1
+        assert len(new_manager.state.orchestration.sprint_backlog) == 0
+
+        new_orchestrator = Orchestrator(engineer_app=mock_engineer_app, manager=new_manager)
+
+        # 3. Call dispatcher again
+        result = await new_orchestrator.node_backlog_dispatcher(new_manager.state)
+
+        # 4. Assert no new task is dispatched
+        assert "engineering" not in result or result["engineering"] is None
+        # OR if it returns orchestration only
+        if "engineering" in result:
+             # If it returned a new engineering state it would have a current_task
+             # node_backlog_dispatcher returns {"orchestration": orch, "engineering": new_eng} if a task is found
+             # otherwise it returns {"orchestration": orch}
+             pass
+
+        # Check that no task in sprint_backlog is IN_PROGRESS
+        assert all(t.status != "IN_PROGRESS" for t in new_manager.state.orchestration.sprint_backlog)


### PR DESCRIPTION
This PR addresses the schema non-compliance in the studio state seed files and implements mandatory state persistence logic in the Orchestrator.

Key Changes:
1. **Schema Compliance:** Regenerated both `studio_state.seed.json` and `studio/studio_state.seed.json` using the `StudioState` Pydantic model. This ensures that cold starts using these seeds will pass validation.
2. **State Persistence:** Modified the `Orchestrator` to accept a `StudioManager` instance. Explicit `_save_state()` calls were added to the `node_backlog_dispatcher` (when a task is completed or failed) and the `_engineer_wrapper` (when a circuit breaker is triggered), ensuring AGENTS.md compliance and preventing data loss during crashes.
3. **Integration:** Updated `main.py` to correctly initialize the `Orchestrator` with the `StudioManager`.
4. **Testing:** Added a new test suite `tests/test_persistence_transitions.py` to verify:
   - Atomic state saving on task completion.
   - Immediate state saving on circuit breaker activation.
   - Proper recovery and idempotency (no re-dispatching of completed tasks).
5. **Robustness:** Updated existing tests in `tests/test_orchestrator.py` and the new tests to mock `sync_main_branch`, avoiding failures caused by local Git state during testing.

These changes improve system reliability, reproducibility, and alignment with the project's architectural principles.

Fixes #278

---
*PR created automatically by Jules for task [7474125818803811681](https://jules.google.com/task/7474125818803811681) started by @jonaschen*