### PR TITLE
Update seed states to match Pydantic schema and add recovery tests

### DIFF
--- a/studio/studio_state.seed.json
+++ b/studio/studio_state.seed.json
@@ -1,120 +1,31 @@
 {
-  "studio_meta": {
-    "system_version": "5.1.0",
-    "constitution_hash": "sha256:a1b2c3d4...",
-    "current_phase": "MVP_SCAFFOLDING",
-    "simulation_mode": false,
-    "last_updated": "2026-02-08T10:00:00Z"
+  "system_version": "5.2.0",
+  "circuit_breaker_triggered": false,
+  "escalation_triggered": false,
+  "orchestration": {
+    "session_id": "SESSION-00",
+    "user_intent": "BOOTSTRAP",
+    "full_logs": "",
+    "triage_status": null,
+    "guidance_sop": null,
+    "current_context_slice": null,
+    "task_queue": [],
+    "task_max_retries": 5,
+    "current_sprint_id": null,
+    "sprint_goal": null,
+    "sprint_backlog": [],
+    "completed_tasks_log": [],
+    "failed_tasks_log": []
   },
-
-  "orchestration_state": {
-    "sprint_board": {
-      "sprint_id": "SPRINT-01",
-      "sprint_goal": "Implement Supervisor Agent Log Chunking Strategy (Fix #3)",
-      "start_date": "2026-02-08",
-      "end_date": "2026-02-22",
-      "tickets": {
-        "TKT-101": {
-          "id": "TKT-101",
-          "title": "Setup Vertex AI Client",
-          "status": "DONE",
-          "assigned_to": "Engineer",
-          "priority": "HIGH"
-        },
-        "TKT-102": {
-          "id": "TKT-102",
-          "title": "Implement Log Chunking (>50MB)",
-          "status": "IN_PROGRESS",
-          "assigned_to": "Engineer",
-          "priority": "CRITICAL",
-          "acceptance_criteria": [
-            "Must verify file size > 50MB",
-            "Must slice last 5000 lines or +/- 10s from failure"
-          ]
-        }
-      },
-      "blockers": []
-    },
-    "inquiry_session": {
-      "_privacy_level": "CONFIDENTIAL_USER_DATA",
-      "session_id": "SESS-8829",
-      "user_intent": "Debug Kernel Panic on Resume",
-      "interaction_history": [
-        {
-          "role": "user",
-          "content": "My device hangs during suspend. Logs attached.",
-          "timestamp": "2026-02-08T09:30:00Z"
-        }
-      ],
-      "active_agent": "Engineer"
-    }
-  },
-
-  "engineering_state": {
-    "workspace_snapshot": {
-      "current_file": "product/agents/supervisor.py",
-      "git_branch": "feature/log-chunking",
-      "diff_stat": "+45 lines, -2 lines"
-    },
-    "code_artifacts": {
-      "proposed_patch": "def chunk_log(file_path): ...",
-      "justification_refs": [
-        "PRODUCT_BLUEPRINT.md#Section2.Supervisor",
-        "TKT-102#AcceptanceCriteria"
-      ],
-      "lint_score": 9.8
-    },
+  "engineering": {
+    "current_task": null,
     "verification_gate": {
-      "status": "RED",
-      "latest_test_run": {
-        "test_id": "test_chunking_large_file",
-        "outcome": "FAIL",
-        "error_message": "IndexError: list index out of range",
-        "duration_ms": 142
-      },
-      "failure_counter": 1
-    }
+      "status": "PENDING",
+      "failure_counter": 0,
+      "blocking_reason": null
+    },
+    "proposed_patch": null,
+    "jules_meta": null
   },
-
-  "optimization_state": {
-    "target_prompt": "product/prompts/pathologist.yaml",
-    "optimization_trajectory": [
-      {
-        "iteration": 1,
-        "prompt_hash": "abc1234",
-        "score": 0.72,
-        "feedback": "Agent failed to identify the file path correctly."
-      }
-    ],
-    "hard_negatives": [
-      {
-        "input_id": "case_005_obfuscated_path",
-        "expected": "drivers/gpu/drm/msm/mdss.c",
-        "actual": "drivers/gpu/drm/msm/mdss_dsi.c"
-      }
-    ]
-  },
-
-  "episodic_memory": {
-    "architectural_decision_records": [
-      {
-        "id": "ADR-001",
-        "title": "Adopt LangGraph for State Management",
-        "date": "2026-02-08",
-        "status": "ACCEPTED",
-        "consequences": [
-          "Requires strict schema definition (Pydantic)",
-          "Enables time-travel debugging"
-        ]
-      }
-    ],
-    "retrospective_insights": [
-      {
-        "sprint_id": "SPRINT-00",
-        "insight_type": "PROCESS_IMPROVEMENT",
-        "observation": "Engineer hallucinates file paths without grep.",
-        "action_item": "Enforce use of 'verify_file_exists' tool in Pathologist prompt."
-      }
-    ]
-  }
+  "privacy_mode": true
 }

--- a/studio/utils/regenerate_seed.py
+++ b/studio/utils/regenerate_seed.py
@@ -1,0 +1,34 @@
+from studio.memory import StudioState, OrchestrationState, EngineeringState, VerificationGate
+import json
+import os
+
+def generate_seed():
+    state = StudioState(
+        system_version="5.2.0",
+        orchestration=OrchestrationState(
+            session_id="SESSION-00",
+            user_intent="BOOTSTRAP"
+        ),
+        engineering=EngineeringState(
+            verification_gate=VerificationGate(status="PENDING")
+        )
+    )
+
+    seed_content = state.model_dump()
+
+    # We need to handle datetime if any were in the defaults,
+    # but looking at the schema, there are none in the top level states
+    # except in nested lists which are empty by default.
+    # Actually, Pydantic's model_dump with mode='json' is better if we had datetimes.
+    # Since we use pydantic v2, let's use model_dump(mode='json')
+
+    seed_json = state.model_dump(mode='json')
+
+    with open("studio_state.seed.json", "w") as f:
+        json.dump(seed_json, f, indent=2)
+
+    with open("studio/studio_state.seed.json", "w") as f:
+        json.dump(seed_json, f, indent=2)
+
+if __name__ == "__main__":
+    generate_seed()

--- a/studio_state.seed.json
+++ b/studio_state.seed.json
@@ -1,31 +1,31 @@
 {
-    "system_version": "5.2.0",
-    "circuit_breaker_triggered": false,
-    "escalation_triggered": false,
-    "orchestration": {
-        "session_id": "RECOVERY-TEST",
-        "user_intent": "BOOTSTRAP",
-        "full_logs": "",
-        "triage_status": null,
-        "guidance_sop": null,
-        "current_context_slice": null,
-        "task_queue": [],
-        "task_max_retries": 5,
-        "current_sprint_id": null,
-        "sprint_goal": null,
-        "sprint_backlog": [],
-        "completed_tasks_log": [],
-        "failed_tasks_log": []
+  "system_version": "5.2.0",
+  "circuit_breaker_triggered": false,
+  "escalation_triggered": false,
+  "orchestration": {
+    "session_id": "SESSION-00",
+    "user_intent": "BOOTSTRAP",
+    "full_logs": "",
+    "triage_status": null,
+    "guidance_sop": null,
+    "current_context_slice": null,
+    "task_queue": [],
+    "task_max_retries": 5,
+    "current_sprint_id": null,
+    "sprint_goal": null,
+    "sprint_backlog": [],
+    "completed_tasks_log": [],
+    "failed_tasks_log": []
+  },
+  "engineering": {
+    "current_task": null,
+    "verification_gate": {
+      "status": "PENDING",
+      "failure_counter": 0,
+      "blocking_reason": null
     },
-    "engineering": {
-        "current_task": null,
-        "verification_gate": {
-            "status": "PENDING",
-            "failure_counter": 0,
-            "blocking_reason": null
-        },
-        "proposed_patch": null,
-        "jules_meta": null
-    },
-    "privacy_mode": true
+    "proposed_patch": null,
+    "jules_meta": null
+  },
+  "privacy_mode": true
 }


### PR DESCRIPTION
This submission updates the seed state files (`studio_state.seed.json` in root and `studio/`) to strictly conform to the Pydantic `StudioState` schema, ensuring reliable bootstrapping and removing legacy/non-existent fields. 

Key changes:
- **Seed Synchronization**: Both seed files now exactly match the `StudioState` structure, including top-level `system_version`, `orchestration`, and `engineering` fields.
- **Regeneration Utility**: Added `studio/utils/regenerate_seed.py` to allow developers to easily update seeds if the schema changes in the future.
- **Resilience Testing**: Added a new test case in `tests/studio_tests/test_persistence_transitions.py` that simulates a system crash and restart, verifying that the state is correctly reloaded from disk and that already-completed tasks are not re-executed.

These changes improve system stability, reproducibility for new contributors, and verify the robustness of the state persistence layer.

Fixes #278

---
*PR created automatically by Jules for task [11153196052970536969](https://jules.google.com/task/11153196052970536969) started by @jonaschen*