### PR TITLE
Update Seed State for Phase 1 Completion and Sprint Activation

### DIFF
--- a/studio/studio_state.seed.json
+++ b/studio/studio_state.seed.json
@@ -4,7 +4,7 @@
   "escalation_triggered": false,
   "orchestration": {
     "session_id": "SESSION-00",
-    "user_intent": "BOOTSTRAP",
+    "user_intent": "SPRINT",
     "full_logs": "",
     "triage_status": null,
     "guidance_sop": null,
@@ -14,7 +14,34 @@
     "current_sprint_id": null,
     "sprint_goal": null,
     "sprint_backlog": [],
-    "completed_tasks_log": [],
+    "completed_tasks_log": [
+      {
+        "id": "TKT-001",
+        "title": "Agent Personas & I/O Contracts",
+        "description": "Schemas implemented in product/schemas.py",
+        "priority": "HIGH",
+        "dependencies": [],
+        "source_section_id": "Phase 1",
+        "status": "COMPLETED",
+        "failure_log": null,
+        "retry_count": 0,
+        "closure_reason": "Completed prior to SQLite migration"
+      },
+      {
+        "id": "TKT-002",
+        "title": "Data Contracts & Datasheet Schema",
+        "description": "Datasheet fixtures generated",
+        "priority": "HIGH",
+        "dependencies": [
+          "TKT-001"
+        ],
+        "source_section_id": "Phase 1",
+        "status": "COMPLETED",
+        "failure_log": null,
+        "retry_count": 0,
+        "closure_reason": "Completed prior to SQLite migration"
+      }
+    ],
     "failed_tasks_log": []
   },
   "engineering": {

--- a/studio_state.seed.json
+++ b/studio_state.seed.json
@@ -4,7 +4,7 @@
   "escalation_triggered": false,
   "orchestration": {
     "session_id": "SESSION-00",
-    "user_intent": "BOOTSTRAP",
+    "user_intent": "SPRINT",
     "full_logs": "",
     "triage_status": null,
     "guidance_sop": null,
@@ -14,7 +14,34 @@
     "current_sprint_id": null,
     "sprint_goal": null,
     "sprint_backlog": [],
-    "completed_tasks_log": [],
+    "completed_tasks_log": [
+      {
+        "id": "TKT-001",
+        "title": "Agent Personas & I/O Contracts",
+        "description": "Schemas implemented in product/schemas.py",
+        "priority": "HIGH",
+        "dependencies": [],
+        "source_section_id": "Phase 1",
+        "status": "COMPLETED",
+        "failure_log": null,
+        "retry_count": 0,
+        "closure_reason": "Completed prior to SQLite migration"
+      },
+      {
+        "id": "TKT-002",
+        "title": "Data Contracts & Datasheet Schema",
+        "description": "Datasheet fixtures generated",
+        "priority": "HIGH",
+        "dependencies": [
+          "TKT-001"
+        ],
+        "source_section_id": "Phase 1",
+        "status": "COMPLETED",
+        "failure_log": null,
+        "retry_count": 0,
+        "closure_reason": "Completed prior to SQLite migration"
+      }
+    ],
     "failed_tasks_log": []
   },
   "engineering": {


### PR DESCRIPTION
This submission updates the `studio_state.seed.json` files (both in the root and in the `studio/` directory) to facilitate a warm start after a SQLite checkpointer wipe. 

Key changes:
1.  **User Intent Update**: Changed `orchestration.user_intent` from `"BOOTSTRAP"` to `"SPRINT"` to trigger the sprint loop upon initialization.
2.  **Completed Task Injection**: Added `TKT-001` (Agent Personas & I/O Contracts) and `TKT-002` (Data Contracts & Datasheet Schema) to the `completed_tasks_log` array. This prevents the Product Owner from regenerating these tasks.
3.  **Schema Compliance**: Verified that the modified JSON objects strictly adhere to the `Ticket` and `StudioState` schemas defined in `studio/memory.py` using a validation script.
4.  **Consistency**: Maintained identical state across both seed file locations as required by the repository's state management protocol.
5.  **Testing**: Confirmed that `StudioManager` correctly loads the modified seed files by running existing unit tests (`tests/studio_tests/test_manager.py`).

Fixes #283

---
*PR created automatically by Jules for task [7574110812859673993](https://jules.google.com/task/7574110812859673993) started by @jonaschen*