### PR TITLE
Fix test_consultant_response_schema failure

### DIFF
--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -8,7 +8,7 @@ def test_consultant_response_schema():
     """Test A (Schema Compliance): The output MUST validate against the JSON Schema."""
     valid_data = {
         "diagnosis_id": "RCA-BSP-001",
-        "confidence": 0.9,
+        "confidence_score": 0.9,
         "status": "CRITICAL",
         "root_cause_summary": "Null Pointer Dereference",
         "evidence": ["Timestamp 1456.78: null pointer dereference"],


### PR DESCRIPTION
This change fixes a failing test case in `tests/test_supervisor.py`. The `ConsultantResponse` Pydantic model requires a field named `confidence_score`, but the test was providing a dictionary with the key `confidence`. This caused a `ValidationError` during test execution. I have updated the test data to use the correct field name.

Verified the fix by running `PYTHONPATH=. python3 -m pytest tests/test_supervisor.py`, which now passes all tests.

Fixes #292

---
*PR created automatically by Jules for task [13483833847630037876](https://jules.google.com/task/13483833847630037876) started by @jonaschen*