### PR TITLE
Fix QA Sandbox Git Checkout Trap (Stale Branch Testing)

### DIFF
--- a/studio/utils/git_utils.py
+++ b/studio/utils/git_utils.py
@@ -30,6 +30,14 @@ def checkout_pr_branch(branch_name: str):
         logger.error(f"Git checkout {branch_name} failed: {e}")
         raise
 
+    # 4. Force synchronization with origin (Hard Reset)
+    # This ensures local branch perfectly mirrors origin, avoiding "Checkout Trap"
+    try:
+        subprocess.run(["git", "reset", "--hard", f"origin/{branch_name}"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git reset --hard origin/{branch_name} failed: {e}")
+        raise
+
 def sync_main_branch():
     """
     Synchronizes the local main branch with the remote origin.

--- a/tests/studio_tests/test_git_utils.py
+++ b/tests/studio_tests/test_git_utils.py
@@ -12,7 +12,7 @@ class TestGitUtils(unittest.TestCase):
         checkout_pr_branch(branch_name)
 
         # Verify the sequence of git commands
-        self.assertEqual(mock_run.call_count, 3)
+        self.assertEqual(mock_run.call_count, 4)
 
         # 1. git stash
         mock_run.assert_any_call(["git", "stash"], check=False)
@@ -22,6 +22,9 @@ class TestGitUtils(unittest.TestCase):
 
         # 3. git checkout branch_name
         mock_run.assert_any_call(["git", "checkout", branch_name], check=True)
+
+        # 4. git reset --hard origin/branch_name
+        mock_run.assert_any_call(["git", "reset", "--hard", f"origin/{branch_name}"], check=True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR fixes the "Checkout Trap" issue where the QA sandbox would repeatedly test stale code from an existing local branch instead of the newly pushed commits from the remote origin. 

Changes:
1. Modified `studio/utils/git_utils.py`: Added a `git reset --hard origin/{branch_name}` command to the `checkout_pr_branch` function. This ensures that the local branch is forcefully synchronized with the remote origin after being checked out.
2. Updated `tests/studio_tests/test_git_utils.py`: Updated the unit tests to verify that the new `git reset --hard` command is executed as part of the checkout sequence.

These changes ensure idempotency and prevent automated CI failures due to merge conflicts in the sandbox environment.

Fixes #299

---
*PR created automatically by Jules for task [6221104889634575702](https://jules.google.com/task/6221104889634575702) started by @jonaschen*