### PR TITLE
🧪 [Testing] Add tests for verify_unused.py

### DIFF
--- a/tests/test_verify_unused.py
+++ b/tests/test_verify_unused.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch, mock_open
+from io import StringIO
+import ast
+
+from verify_unused import check_unused_imports
+
+class TestVerifyUnused(unittest.TestCase):
+    def test_optional_is_used(self):
+        code = '''
+from typing import Optional
+
+def func(x: Optional[int]) -> None:
+    pass
+'''
+        with patch('builtins.open', mock_open(read_data=code)):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                check_unused_imports('dummy_path.py')
+                self.assertEqual(fake_out.getvalue().strip(), "Optional is USED.")
+
+    def test_optional_is_not_used(self):
+        code = '''
+from typing import Optional
+
+def func(x: int) -> None:
+    pass
+'''
+        with patch('builtins.open', mock_open(read_data=code)):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                check_unused_imports('dummy_path.py')
+                self.assertEqual(fake_out.getvalue().strip(), "Optional is NOT used.")
+
+    def test_optional_used_in_assignment(self):
+        code = '''
+from typing import Optional
+
+MyOpt = Optional[str]
+'''
+        with patch('builtins.open', mock_open(read_data=code)):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                check_unused_imports('dummy_path.py')
+                self.assertEqual(fake_out.getvalue().strip(), "Optional is USED.")
+
+    def test_syntax_error(self):
+        code = '''
+from typing import Optional
+def func(x: int
+    pass
+'''
+        with patch('builtins.open', mock_open(read_data=code)):
+            with self.assertRaises(SyntaxError):
+                check_unused_imports('dummy_path.py')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `verify_unused.py` script. The script's logic for parsing an AST to check for unused imports (specifically 'Optional') was entirely untested.

📊 **Coverage:** The new `tests/test_verify_unused.py` file uses `unittest` and `unittest.mock.patch` to cover four key scenarios without needing actual files on disk:
- When `Optional` is correctly imported and used.
- When `Optional` is correctly imported but NOT used.
- When `Optional` is used in a type assignment/alias.
- When the parsed code has a `SyntaxError` (verifying proper exception bubbling).

✨ **Result:** Increased testing coverage for `verify_unused.py` ensures any future refactoring of the AST parsing logic will be caught by deterministic unit tests.

---
*PR created automatically by Jules for task [16793061432586528265](https://jules.google.com/task/16793061432586528265) started by @jonaschen*