### PR TITLE
🧪 Add missing test for regenerate_seed.py

### DIFF
--- a/tests/studio_tests/test_regenerate_seed.py
+++ b/tests/studio_tests/test_regenerate_seed.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch, mock_open
+import json
+from studio.utils.regenerate_seed import generate_seed
+from studio.memory import StudioState, OrchestrationState, EngineeringState, VerificationGate
+
+def test_generate_seed():
+    """
+    Tests that generate_seed creates the correct StudioState and writes it
+    to both studio_state.seed.json and studio/studio_state.seed.json
+    with the correct JSON formatting.
+    """
+    with patch("builtins.open", mock_open()) as mocked_file, \
+         patch("json.dump") as mocked_json_dump:
+
+        generate_seed()
+
+        # Verify open was called twice with correct paths
+        assert mocked_file.call_count == 2
+        mocked_file.assert_any_call("studio_state.seed.json", "w")
+        mocked_file.assert_any_call("studio/studio_state.seed.json", "w")
+
+        # Construct the expected state to compare
+        expected_state = StudioState(
+            system_version="5.2.0",
+            orchestration=OrchestrationState(
+                session_id="SESSION-00",
+                user_intent="BOOTSTRAP"
+            ),
+            engineering=EngineeringState(
+                verification_gate=VerificationGate(status="PENDING")
+            )
+        )
+        expected_json = expected_state.model_dump(mode='json')
+
+        # Verify json.dump was called twice with correct arguments
+        assert mocked_json_dump.call_count == 2
+        for call_args in mocked_json_dump.call_args_list:
+            args, kwargs = call_args
+            assert args[0] == expected_json
+            # args[1] is the mock file object
+            assert kwargs == {"indent": 2}


### PR DESCRIPTION
🎯 **What:** This PR addresses a missing test file for `studio/utils/regenerate_seed.py`. The `generate_seed` function constructs a `StudioState` via Pydantic and serializes it to JSON seed files, which was previously untested.

📊 **Coverage:** The new test covers the happy path scenario for generating the seed, including:
- Construction of the expected `StudioState` Pydantic model.
- Serializing the model to a JSON structure with `indent=2`.
- Verifying that it correctly attempts to write the JSON to both `studio_state.seed.json` and `studio/studio_state.seed.json` using mocked file I/O.

✨ **Result:** Test coverage is improved by fully validating the behavior of the `generate_seed` script safely without causing actual disk writes or flaky test conditions.

---
*PR created automatically by Jules for task [8265668007009289634](https://jules.google.com/task/8265668007009289634) started by @jonaschen*