### PR TITLE
Fix Serialization Crash and Harden Git Sync

### DIFF
--- a/studio/orchestrator.py
+++ b/studio/orchestrator.py
@@ -241,7 +241,7 @@ class Orchestrator:
             jules_meta = JulesMetadata(
                 session_id=orch.session_id,
                 max_retries=orch.task_max_retries
-            ).model_dump()
+            ).model_dump(mode='json')
 
             new_eng = EngineeringState(
                 current_task=f"{next_ticket.title}: {next_ticket.description}",
@@ -316,7 +316,7 @@ class Orchestrator:
         # Ensure it is a dict for the Subgraph which expects Union[Dict, JulesMetadata]
         # and ultimately dumps it back.
         if isinstance(jules_metadata_raw, JulesMetadata):
-            jules_metadata = jules_metadata_raw.model_dump()
+            jules_metadata = jules_metadata_raw.model_dump(mode='json')
         else:
             jules_metadata = jules_metadata_raw
 
@@ -360,7 +360,7 @@ class Orchestrator:
         # Store as dict for serialization
         eng_update = state.engineering.model_copy(update={
             "proposed_patch": proposed_patch or "No patch generated",
-            "jules_meta": jules_meta.model_dump(),
+            "jules_meta": jules_meta.model_dump(mode='json'),
             "verification_gate": VerificationGate(status=gate_status)
         })
 

--- a/studio/subgraphs/engineer.py
+++ b/studio/subgraphs/engineer.py
@@ -186,7 +186,7 @@ async def node_task_dispatcher(state: AgentState) -> Dict[str, Any]:
         jules_data.external_task_id = task_id
         jules_data.status = "WORKING"
 
-    return {"jules_metadata": jules_data.model_dump()}
+    return {"jules_metadata": jules_data.model_dump(mode='json')}
 
 
 # --- 2. Watch Tower Node (The Asynchronous Poller) ---
@@ -221,7 +221,7 @@ async def node_watch_tower(state: AgentState) -> Dict[str, Any]:
 
     if not jules_data.external_task_id:
         # Safety check - should not happen due to graph topology
-        return {"jules_metadata": jules_data.model_dump()}
+        return {"jules_metadata": jules_data.model_dump(mode='json')}
 
     logger.info(f"Watch_Tower: Polling task {jules_data.external_task_id}")
 
@@ -231,7 +231,7 @@ async def node_watch_tower(state: AgentState) -> Dict[str, Any]:
     except Exception as e:
         logger.error(f"Polling failed: {e}")
         # Transient error handling strategy could be implemented here
-        return {"jules_metadata": jules_data.model_dump()} # Retry next loop
+        return {"jules_metadata": jules_data.model_dump(mode='json')} # Retry next loop
 
     # 2. State Mapping
     if remote_status.status == "COMPLETED":
@@ -252,7 +252,7 @@ async def node_watch_tower(state: AgentState) -> Dict[str, Any]:
         if remote_status.last_commit_hash == jules_data.last_verified_commit:
             logger.info(f"Review ready but commit hash {remote_status.last_commit_hash} already verified. Waiting for new changes.")
             jules_data.status = "WORKING"
-            return {"jules_metadata": jules_data.model_dump()}
+            return {"jules_metadata": jules_data.model_dump(mode='json')}
 
         logger.info(f"New commit detected ({remote_status.last_commit_hash}). Proceeding to Entropy Check/Verification.")
         jules_data.status = "VERIFYING"
@@ -277,7 +277,7 @@ async def node_watch_tower(state: AgentState) -> Dict[str, Any]:
         # WORKING or QUEUED
         jules_data.status = "WORKING"
 
-    return {"jules_metadata": jules_data.model_dump()}
+    return {"jules_metadata": jules_data.model_dump(mode='json')}
 
 
 # --- 3. Entropy Guard Node (The Cognitive Circuit Breaker) ---
@@ -343,11 +343,11 @@ async def node_entropy_guard(state: AgentState) -> Dict[str, Any]:
 
         # Inject a meta-message to the graph history
         return {
-            "jules_metadata": jules_data.model_dump(),
+            "jules_metadata": jules_data.model_dump(mode='json'),
             "messages": [AIMessage(content="**SYSTEM**: Circuit Breaker Tripped. Cognitive Tunneling detected.")]
         }
 
-    return {"jules_metadata": jules_data.model_dump()}
+    return {"jules_metadata": jules_data.model_dump(mode='json')}
 
 
 # --- 4. QA Verifier Node (The Gatekeeper) ---
@@ -385,7 +385,7 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
             )
             jules_data.test_results_history.append(result)
             jules_data.status = "FAILED"
-            return {"jules_metadata": jules_data.model_dump()}
+            return {"jules_metadata": jules_data.model_dump(mode='json')}
 
     # 1. Prepare Files
     # We need to gather all relevant files (context + modified)
@@ -530,11 +530,11 @@ async def node_qa_verifier(state: AgentState) -> Dict[str, Any]:
 
             jules_data.status = "COMPLETED" # We accept the fallback
             jules_data.is_refactoring = False
-            return {"jules_metadata": jules_data.model_dump()}
+            return {"jules_metadata": jules_data.model_dump(mode='json')}
 
         jules_data.status = "FAILED"
 
-    return {"jules_metadata": jules_data.model_dump()}
+    return {"jules_metadata": jules_data.model_dump(mode='json')}
 
 # --- 5. Architect Gate Node (The Design Authority) ---
 
@@ -633,7 +633,7 @@ async def node_architect_gate(state: AgentState) -> Dict[str, Any]:
                 client.review_pr(jules_data.last_verified_pr_number, event="REQUEST_CHANGES", body=feedback)
 
             return {
-                "jules_metadata": jules_data.model_dump(),
+                "jules_metadata": jules_data.model_dump(mode='json'),
                 "messages": [AIMessage(content="**SYSTEM**: Architect rejected the solution. Refactor attempt 1/1 initiated.")]
             }
         else:
@@ -652,7 +652,7 @@ async def node_architect_gate(state: AgentState) -> Dict[str, Any]:
                 jules_data.status = "COMPLETED"
                 jules_data.is_refactoring = False
                 return {
-                    "jules_metadata": jules_data.model_dump(),
+                    "jules_metadata": jules_data.model_dump(mode='json'),
                     "messages": [AIMessage(content="**SYSTEM**: Refactor limit reached. Fallback to Green state with Tech Debt tag.")]
                 }
 
@@ -666,7 +666,7 @@ async def node_architect_gate(state: AgentState) -> Dict[str, Any]:
         logger.info(f"Architect_Gate: Merging PR #{jules_data.last_verified_pr_number}")
         client.merge_pr(jules_data.last_verified_pr_number)
 
-    return {"jules_metadata": jules_data.model_dump()}
+    return {"jules_metadata": jules_data.model_dump(mode='json')}
 
 
 # --- 6. Feedback Loop Node (The Correction Engine) ---
@@ -772,7 +772,7 @@ async def node_feedback_loop(state: AgentState) -> Dict[str, Any]:
         messages.append(AIMessage(content="**SYSTEM**: Max retries exceeded. Escalating to Orchestrator/Human for manual intervention."))
 
     return {
-        "jules_metadata": jules_data.model_dump(),
+        "jules_metadata": jules_data.model_dump(mode='json'),
         "messages": messages
     }
 

--- a/studio/utils/git_utils.py
+++ b/studio/utils/git_utils.py
@@ -38,12 +38,25 @@ def checkout_pr_branch(branch_name: str):
         logger.error(f"Git reset --hard origin/{branch_name} failed: {e}")
         raise
 
+    # 5. Clean untracked files
+    try:
+        subprocess.run(["git", "clean", "-fd"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git clean -fd failed: {e}")
+        raise
+
 def sync_main_branch():
     """
     Synchronizes the local main branch with the remote origin.
-    Executes: git checkout main && git pull origin main --rebase
+    Executes: git stash && git checkout main && git fetch origin main && git reset --hard origin/main && git clean -fd
     """
     logger.info("Synchronizing local workspace with main branch.")
+
+    # 0. Stash local changes
+    try:
+        subprocess.run(["git", "stash"], check=False)
+    except Exception as e:
+        logger.warning(f"Git stash failed: {e}")
 
     # 1. Checkout main
     try:
@@ -52,9 +65,23 @@ def sync_main_branch():
         logger.error(f"Git checkout main failed: {e}")
         raise
 
-    # 2. Pull from origin main (with rebase to avoid merge conflicts in automated flow)
+    # 2. Fetch from origin main
     try:
-        subprocess.run(["git", "pull", "--rebase", "origin", "main"], check=True)
+        subprocess.run(["git", "fetch", "origin", "main"], check=True)
     except subprocess.CalledProcessError as e:
-        logger.error(f"Git pull origin main failed: {e}")
+        logger.error(f"Git fetch origin main failed: {e}")
+        raise
+
+    # 3. Force synchronization with origin/main
+    try:
+        subprocess.run(["git", "reset", "--hard", "origin/main"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git reset --hard origin/main failed: {e}")
+        raise
+
+    # 4. Clean untracked files
+    try:
+        subprocess.run(["git", "clean", "-fd"], check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Git clean -fd failed: {e}")
         raise

--- a/tests/studio_tests/test_git_utils.py
+++ b/tests/studio_tests/test_git_utils.py
@@ -13,7 +13,7 @@ class TestGitUtils(unittest.TestCase):
         checkout_pr_branch(branch_name)
 
         # Verify the sequence of git commands
-        self.assertEqual(mock_run.call_count, 4)
+        self.assertEqual(mock_run.call_count, 5)
 
         # 1. git stash
         mock_run.assert_any_call(["git", "stash"], check=False)
@@ -27,31 +27,33 @@ class TestGitUtils(unittest.TestCase):
         # 4. git reset --hard origin/branch_name
         mock_run.assert_any_call(["git", "reset", "--hard", f"origin/{branch_name}"], check=True)
 
+        # 5. git clean -fd
+        mock_run.assert_any_call(["git", "clean", "-fd"], check=True)
+
     @patch("subprocess.run")
     def test_sync_main_branch_success(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
 
         sync_main_branch()
 
-        self.assertEqual(mock_run.call_count, 2)
+        self.assertEqual(mock_run.call_count, 5)
+        # 1. git stash
+        mock_run.assert_any_call(["git", "stash"], check=False)
+        # 2. git checkout main
         mock_run.assert_any_call(["git", "checkout", "main"], check=True)
-        mock_run.assert_any_call(["git", "pull", "--rebase", "origin", "main"], check=True)
+        # 3. git fetch origin main
+        mock_run.assert_any_call(["git", "fetch", "origin", "main"], check=True)
+        # 4. git reset --hard origin/main
+        mock_run.assert_any_call(["git", "reset", "--hard", "origin/main"], check=True)
+        # 5. git clean -fd
+        mock_run.assert_any_call(["git", "clean", "-fd"], check=True)
 
     @patch("subprocess.run")
     def test_sync_main_branch_checkout_failure(self, mock_run):
-        mock_run.side_effect = subprocess.CalledProcessError(returncode=1, cmd=["git", "checkout", "main"])
-
-        with self.assertRaises(subprocess.CalledProcessError):
-            sync_main_branch()
-
-        self.assertEqual(mock_run.call_count, 1)
-        mock_run.assert_called_once_with(["git", "checkout", "main"], check=True)
-
-    @patch("subprocess.run")
-    def test_sync_main_branch_pull_failure(self, mock_run):
+        # First call is git stash (succeeds), second is git checkout main (fails)
         def side_effect(*args, **kwargs):
             cmd = args[0]
-            if "pull" in cmd:
+            if cmd == ["git", "checkout", "main"]:
                 raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
             return MagicMock(returncode=0)
 
@@ -61,8 +63,26 @@ class TestGitUtils(unittest.TestCase):
             sync_main_branch()
 
         self.assertEqual(mock_run.call_count, 2)
+        mock_run.assert_any_call(["git", "stash"], check=False)
         mock_run.assert_any_call(["git", "checkout", "main"], check=True)
-        mock_run.assert_any_call(["git", "pull", "--rebase", "origin", "main"], check=True)
+
+    @patch("subprocess.run")
+    def test_sync_main_branch_fetch_failure(self, mock_run):
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if "fetch" in cmd:
+                raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = side_effect
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            sync_main_branch()
+
+        self.assertEqual(mock_run.call_count, 3)
+        mock_run.assert_any_call(["git", "stash"], check=False)
+        mock_run.assert_any_call(["git", "checkout", "main"], check=True)
+        mock_run.assert_any_call(["git", "fetch", "origin", "main"], check=True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/studio_tests/test_memory.py
+++ b/tests/studio_tests/test_memory.py
@@ -105,3 +105,35 @@ def test_jules_metadata_union_type_support():
     state_dump = studio_state.model_dump()
     json_str = json.dumps(state_dump)
     assert json_str is not None
+
+def test_jules_metadata_httpurl_serialization():
+    """
+    Verifies that JulesMetadata with HttpUrl can be serialized when using mode='json'.
+    This is the specific fix for the reported system crash.
+    """
+    from studio.memory import CodeChangeArtifact
+    import ormsgpack
+
+    artifact = CodeChangeArtifact(
+        diff_content="--- a/file.py\n+++ b/file.py\n@@ -1,1 +1,1 @@\n-old\n+new",
+        pr_link="https://github.com/test/repo/pull/1"
+    )
+    meta = JulesMetadata(
+        session_id="test-session",
+        generated_artifacts=[artifact]
+    )
+
+    # 1. model_dump() without mode='json' should STILL contain HttpUrl object (fails msgpack)
+    dump_raw = meta.model_dump()
+    assert not isinstance(dump_raw["generated_artifacts"][0]["pr_link"], str)
+
+    with pytest.raises(TypeError, match="Type is not msgpack serializable: HttpUrl"):
+        ormsgpack.packb(dump_raw)
+
+    # 2. model_dump(mode='json') MUST convert HttpUrl to string (passes msgpack)
+    dump_json = meta.model_dump(mode='json')
+    assert isinstance(dump_json["generated_artifacts"][0]["pr_link"], str)
+    assert dump_json["generated_artifacts"][0]["pr_link"] == "https://github.com/test/repo/pull/1"
+
+    packed = ormsgpack.packb(dump_json)
+    assert packed is not None


### PR DESCRIPTION
This change fixes a critical system crash occurring during state persistence when `JulesMetadata` contains `HttpUrl` objects (e.g., in `pr_link`). By using Pydantic's `model_dump(mode='json')`, these objects are converted to strings, which `ormsgpack` can handle. 

Additionally, it hardens the Git synchronization logic to be more resilient and idempotent, ensuring automated flows can recover from stale or inconsistent local states without interactive merge conflict resolution.

Fixes #306

---
*PR created automatically by Jules for task [1805394712278732859](https://jules.google.com/task/1805394712278732859) started by @jonaschen*