### PR TITLE
🧹 Code Health: Remove unused SecretStr import in find_pr.py

### DIFF
--- a/find_pr.py
+++ b/find_pr.py
@@ -1,6 +1,5 @@
 from studio.utils.jules_client import JulesGitHubClient
 from studio.config import get_settings
-from pydantic import SecretStr
 
 settings = get_settings()
 client = JulesGitHubClient(


### PR DESCRIPTION
🎯 **What:** Removed unused `SecretStr` import from `pydantic` in `find_pr.py`.
💡 **Why:** To address a code health issue involving dead code, improving codebase cleanliness and maintainability.
✅ **Verification:** Verified by ensuring `find_pr.py` successfully compiles via `python3 -m py_compile find_pr.py`. Ran Pytest which resulted in no related failures.
✨ **Result:** Improved file hygiene and readability without altering any logic.

---
*PR created automatically by Jules for task [2231364219193370726](https://jules.google.com/task/2231364219193370726) started by @jonaschen*