### PR TITLE
🧹 [code health improvement] Remove unused asyncio import in engineer.py

### DIFF
--- a/history/studio/subgraphs/engineer.py
+++ b/history/studio/subgraphs/engineer.py
@@ -8,7 +8,6 @@ This graph enforces the 'Micro-Loop' of the Cognitive Software Factory:
 Plan -> Execute -> Monitor (Entropy) -> Verify (TDD) -> Feedback.
 """
 
-import asyncio
 import logging
 import os
 import re


### PR DESCRIPTION
🎯 **What:** Removed an unused `asyncio` import from `history/studio/subgraphs/engineer.py`
💡 **Why:** `asyncio` is not used in the module because all the async coordination logic is inherently managed by langgraph state graphs. Removing it reduces dead code and improves readability.
✅ **Verification:** Verified via test suite run and python compiler validation.
✨ **Result:** A cleaner import block without changing runtime behavior.

---
*PR created automatically by Jules for task [17980034766538018227](https://jules.google.com/task/17980034766538018227) started by @jonaschen*