### PR TITLE
🧹 Code Health: Remove unused `json` import from `cli.py`

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,6 @@ Examples:
     python cli.py --dmesg logs/panic.txt --output result.json --device Pixel_Watch_Proto
 """
 import argparse
-import json
 import sys
 import uuid
 from pathlib import Path


### PR DESCRIPTION
🎯 **What:** Removed an unused `import json` statement from `cli.py` (line 16).
💡 **Why:** `cli.py` natively uses Pydantic's built-in `model_dump_json()` method rather than the standard `json` module library for serializing the diagnostic response. This improves maintainability and cleans up unused overhead.
✅ **Verification:** Verified `cli.py` compiles successfully and cleanly with `python3 -m py_compile cli.py`.
✨ **Result:** Improved codebase maintainability by deleting dead code.

---
*PR created automatically by Jules for task [6253002861303512419](https://jules.google.com/task/6253002861303512419) started by @jonaschen*